### PR TITLE
Fix error with changed protobuffs API.

### DIFF
--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -44,7 +44,7 @@ encode(Msg) when is_atom(Msg) ->
 encode(Msg) when is_tuple(Msg) ->
     MsgType = element(1, Msg),
     Encoder = encoder_for(MsgType),
-    [msg_code(MsgType) | Encoder:iolist(MsgType, Msg)].
+    [msg_code(MsgType) | Encoder:encode(Msg)].
 
 %% @doc Decode a protocol buffer message given its type - if no bytes
 %% return the atom for the message code. Replaces `riakc_pb:decode/2'.


### PR DESCRIPTION
Previously, the generated `*_pb` modules exported a function called `iolist`, but now you simply call `encode` with the PB record.
