### PR TITLE
Add support for the X-Riak-Deleted header.

### DIFF
--- a/include/riak_pb_kv_codec.hrl
+++ b/include/riak_pb_kv_codec.hrl
@@ -29,6 +29,7 @@
 -define(MD_LASTMOD,  <<"X-Riak-Last-Modified">>).
 -define(MD_USERMETA, <<"X-Riak-Meta">>).
 -define(MD_INDEX,    <<"index">>).
+-define(MD_DELETED, <<"X-Riak-Deleted">>).
 
 %% Content-Type for Erlang term_to_binary format
 -define(CTYPE_ERLANG_BINARY, "application/x-erlang-binary").

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -186,6 +186,7 @@ message RpbContent {
     optional uint32 last_mod_usecs = 8;
     repeated RpbPair usermeta = 9;       // user metadata stored with the object
     repeated RpbPair indexes = 10;       // user metadata stored with the object
+    optional bool deleted = 11;
 }
 
 // Link metadata


### PR DESCRIPTION
Make the riak erlang protocol buffers client aware of the `X-Riak-Deleted` header so that the header is included with other object metadata.
