### PR TITLE
Changes to encoding and decoding of rbppair records.

### DIFF
--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -185,9 +185,9 @@ to_list(V) when is_integer(V) ->
 %% @doc Convert {K,V} tuple to protocol buffers
 -spec encode_pair({Key::binary(), Value::any()}) -> #rpbpair{}.
 encode_pair({K,V}) ->
-    #rpbpair{key = K, value = to_list(V)}.
+    #rpbpair{key = to_binary(K), value = to_binary(V)}.
 
 %% @doc Convert RpbPair PB message to erlang {K,V} tuple
 -spec decode_pair(#rpbpair{}) -> {string(), string()}.
 decode_pair(#rpbpair{key = K, value = V}) ->
-    {binary_to_list(K), binary_to_list(V)}.
+    {K, V}.

--- a/test/encoding_test.erl
+++ b/test/encoding_test.erl
@@ -15,10 +15,11 @@ pb_test_() ->
                                             {{<<"b2">>, <<"k2">>}, <<"v2">>}
                                            ]},
                                {?MD_LASTMOD, {1, 2, 3}},
-                               {?MD_USERMETA, [{"X-Riak-Meta-MyMetaData1","here it is"},
-                                               {"X-Riak-Meta-MoreMd", "have some more"}
+                               {?MD_USERMETA, [{<<"X-Riak-Meta-MyMetaData1">>, <<"here it is">>},
+                                               {<<"X-Riak-Meta-MoreMd">>, <<"have some more">>},
+                                               {<<"X-Riak-Meta-EvenMoreMd">>, term_to_binary({a,b,c,d,e,f})}
                                               ]},
-                               {?MD_INDEX, [{"index_bin", "foo"}]},
+                               {?MD_INDEX, [{<<"index_bin">>, <<"foo">>}]},
                                {?MD_DELETED, true}
                               ]),
                  Value = <<"test value">>,


### PR DESCRIPTION
Change the `encode_pair` function in the `riak_pb_codec` module to encode both the key and value as binaries and changes the `decode_pair` function to return the key and value of the pair as-is. Also add a regression test case to the `encoding_test` module.
