### PR TITLE
Add clause to to_binary/1 that handles an integer() value

### DIFF
--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -160,7 +160,7 @@ decode_bool(false) -> false;
 decode_bool(0) -> false;
 decode_bool(1) -> true.
 
-%% @doc Make sure an atom/string/binary is definitely a
+%% @doc Make sure an atom/string/binary/integer is definitely a
 %% binary. Replaces `riakc_pb:to_binary/1'.
 -spec to_binary(atom() | string() | binary()) -> binary().
 to_binary(A) when is_atom(A) ->
@@ -168,7 +168,9 @@ to_binary(A) when is_atom(A) ->
 to_binary(L) when is_list(L) ->
     list_to_binary(L);
 to_binary(B) when is_binary(B) ->
-    B.
+    B;
+to_binary(I) when is_integer(I) ->
+    list_to_binary(integer_to_list(I)).
 
 %% @doc Converts an arbitrary type to a list for sending in a
 %% PB. Replaces `riakc_pb:any_to_list/1'.

--- a/test/encoding_test.erl
+++ b/test/encoding_test.erl
@@ -2,6 +2,7 @@
 -compile([export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -include("riak_pb_kv_codec.hrl").
+-include("riak_pb.hrl").
 
 pb_test_() ->
     [{"content encode decode",
@@ -97,6 +98,13 @@ pb_test_() ->
                  MdSame = (lists:sort(Props) =:=
                                lists:sort(Props2)),
                  ?assertEqual(true, MdSame)
+             end)},
+     {"Int index rpbpair",
+      ?_test(begin
+                 Index = #rpbpair{key="index_int", value=100},
+                 ErlangyFy = riak_pb_codec:decode_pair(Index),
+                 PBify = riak_pb_codec:encode_pair(ErlangyFy),
+                 ?assertEqual({rpbpair, <<"index_int">>, <<"100">>}, PBify)
              end)}
     ]
         .


### PR DESCRIPTION
The riak java client tests were failing with an int index value since the last commit.

The decode_pair/1 returns exactly what it is given so the int index
value was written to riak, but when returned on the fetch it was
not able to be encoded since there was no clause for integers in
to_binary/1. This adds that clause (and a test.)

Should we actually force to_binary on decode_pair?
