### PR TITLE
Add proto_cmd to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include proto_cmd.py


### PR DESCRIPTION
The package on Pypi is failing to installed because it isn't included in the package. Installing with pip straight from the Github repo does work however.
