### PR TITLE
fix for issue #5 - Add support for most bucket properties to PBC Interface (enhancement)

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -204,4 +204,18 @@ message RpbLink {
 message RpbBucketProps {
     optional uint32 n_val = 1;
     optional bool allow_mult = 2;
+    optional bool last_write_wins = 3;
+    optional bytes backend = 4;
+    optional uint32 r_val = 5;
+    optional uint32 w_val = 6;
+    optional uint32 dw_val = 7;
+    optional uint32 rw_val = 8;
+    repeated RpbPrePostCommitHook precommit = 9;
+    repeated RpbPrePostCommitHook postcommit = 10;
+}
+
+message RpbPrePostCommitHook {
+    optional bytes mod = 1;  // erlang hook module name
+    optional bytes func = 2;  // erlang hook function
+    optional bytes name = 3; // javascript function
 }

--- a/test/encoding_test.erl
+++ b/test/encoding_test.erl
@@ -90,7 +90,15 @@ pb_test_() ->
      {"bucket props encode decode",
       ?_test(begin
                  Props = [{n_val, 99},
-                          {allow_mult, true}],
+                          {allow_mult, true},
+			  {last_write_wins, false},
+			  {backend, <<"leveldb">>},
+			  {r_val, 20},
+			  {w_val, 19},
+			  {dw_val, 18},
+			  {rw_val, 17},
+			  {precommit, []},
+			  {postcommit, [{struct, [{<<"mod">>, <<"testmod">>}, {<<"fun">>, <<"testfun">>}]}]}],
                  Props2 = riak_pb_kv_codec:decode_bucket_props(
                             riak_kv_pb:decode_rpbbucketprops(
                               riak_kv_pb:encode_rpbbucketprops(
@@ -102,7 +110,15 @@ pb_test_() ->
      {"bucket props encode decode 2",
       ?_test(begin
                  Props = [{n_val, 33},
-                          {allow_mult, false}],
+                          {allow_mult, false},
+			  {last_write_wins, true},
+			  {backend, <<"memory">>},
+			  {r_val, 13},
+			  {w_val, 14},
+			  {dw_val, 15},
+			  {rw_val, 16},
+			  {precommit, [{struct, [{<<"name">>, <<"testJSFunc">>}]}]},
+			  {postcommit, []}],
                  Props2 = riak_pb_kv_codec:decode_bucket_props(
                             riak_kv_pb:decode_rpbbucketprops(
                               riak_kv_pb:encode_rpbbucketprops(


### PR DESCRIPTION
Add support for last_write_wins, backend, r, w, dw, rw, precommit, and postcommit bucket
properties when setting/getting bucket properties through the protobuf interface.
