### PR TITLE
Fix errors with repl bucket property.

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -115,10 +115,10 @@ message RpbBucketProps {
 
     // Used by riak_repl bucket fixup
     enum RpbReplMode {
-        off = 0;
+        false = 0;
         realtime = 1;
         fullsync = 2;
-        both = 3;
+        true = 3;
     }
     optional RpbReplMode repl = 22;
 }

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -329,7 +329,7 @@ encode_bucket_props([{backend, B}|Rest], Pb) ->
 encode_bucket_props([{search, S}|Rest], Pb) ->
     encode_bucket_props(Rest, Pb#rpbbucketprops{search = encode_bool(S)});
 encode_bucket_props([{repl, Atom}|Rest], Pb) ->
-    encode_bucket_props(Rest, Pb#rpbbucketprops{repl = Atom});
+    encode_bucket_props(Rest, Pb#rpbbucketprops{repl = encode_repl(Atom)});
 encode_bucket_props([_Ignore|Rest], Pb) ->
     %% Ignore any properties not explicitly part of the PB message
     encode_bucket_props(Rest, Pb).
@@ -391,3 +391,6 @@ decode_commit_hook(#rpbcommithook{modfun = Modfun}) when Modfun =/= undefined ->
     decode_modfun(Modfun, commit_hook);
 decode_commit_hook(#rpbcommithook{name = Name}) when Name =/= undefined ->
     {struct, [{<<"name">>, Name}]}.
+
+encode_repl(both) -> true;
+encode_repl(A) -> A.

--- a/test/bucket_props_codec_eqc.erl
+++ b/test/bucket_props_codec_eqc.erl
@@ -108,7 +108,7 @@ backend() ->
     ?LET(B, non_empty(binary()), {backend, B}).
 
 repl() ->
-    ?LET(R, oneof([off, realtime, fullsync, both]), {repl, R}).
+    ?LET(R, oneof([false, realtime, fullsync, true]), {repl, R}).
 
 commit(Prop) ->
     ?LET(C, non_empty(list(commit_hook())), {Prop, C}).


### PR DESCRIPTION
- 'off' is not a valid setting
- 'true' and 'both' are equivalent, but 'true' is
  backwards-compatible, so we should prefer that.
