### PR TITLE
Add asis flag for RpbPutReq.

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -79,6 +79,7 @@ message RpbPutReq {
     optional bool if_none_match = 10;
     optional bool return_head = 11;
     optional uint32 timeout = 12;
+    optional bool asis = 13;
 }
 
 // Put response - same as get response with optional key if one was generated


### PR DESCRIPTION
This adds just the boolean `asis` flag to `RpbPutReq`, since that flag/behavior can be reviewed independently of #41. @evanmcc has said he will rewrite the history on #41 to exclude this addition.
