### PR TITLE
Remove bucket type field from counter messages, unsupported.

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -248,7 +248,6 @@ message RpbCounterUpdateReq {
     optional uint32 dw = 5;
     optional uint32 pw = 6;
     optional bool returnvalue = 7;
-    optional bytes type = 8;         // Bucket type, if not set we assume the 'default' type
 }
 
 // Counter update response? No message | error response
@@ -264,7 +263,6 @@ message RpbCounterGetReq {
     optional uint32 pr = 4;
     optional bool basic_quorum = 5;
     optional bool notfound_ok = 6;
-    optional bytes type = 7;         // Bucket type, if not set we assume the 'default' type
 }
 
 // Counter value response


### PR DESCRIPTION
The new CRDTs API will allow bucket types.
