### PR TITLE
Add datatype bucket property (read-only)

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -146,7 +146,11 @@ message RpbBucketProps {
     }
     optional RpbReplMode repl = 24;
 
+    // Search index
     optional bytes search_index = 25;
+
+    // KV Datatypes
+    optional bytes datatype = 26;
 }
 
 // Authentication request

--- a/test/bucket_props_codec_eqc.erl
+++ b/test/bucket_props_codec_eqc.erl
@@ -34,7 +34,7 @@
 bucket_codec_test_() ->
     [{"bucket properties encode decode",
       ?_test(begin
-                 eqc:quickcheck(?QC_OUT(eqc:numtests(2000, prop_codec())))
+                 eqc:quickcheck(?QC_OUT(eqc:testing_time(4, prop_codec())))
              end)}].
 
 %%====================================================================
@@ -90,7 +90,9 @@ bucket_prop() ->
            flag(notfound_ok),
            backend(),
            flag(search),
-           repl()]).
+           repl(),
+           yz_index(),
+           datatype()]).
 
 sortuniq(Gen) ->
     ?LET(L, Gen, lists:ukeysort(1,L)).
@@ -132,4 +134,9 @@ atom() ->
 linkfun() ->
     ?LET({M,F}, {atom(), atom()}, {linkfun, {modfun, M, F}}).
 
+datatype() ->
+    {datatype, elements([counter, set, map])}.
+
+yz_index() ->
+    {search_index, non_empty(binary())}.
 -endif.


### PR DESCRIPTION
Also added generators for yz_index and datatype bucket props in the
existing EQC property, and restructured how yz_index was decoded.

@russelldb 
