### PR TITLE
Remove ability for clients to modify bucket types.

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -76,28 +76,13 @@ message RpbResetBucketReq {
     optional bytes type = 2;
 }
 
+// Reset bucket properties response - no message defined, just send
+// RpbResetBucketResp
+
 // Get bucket properties request
 message RpbGetBucketTypeReq {
     required bytes type = 1;
 }
-
-// Set bucket properties request
-message RpbSetBucketTypeReq {
-    required bytes type = 1;
-    required RpbBucketProps props = 2;
-}
-
-// Set bucket properties response - no message defined, just send
-// RpbSetBucketResp
-
-// Reset bucket properties request
-message RpbResetBucketTypeReq {
-    required bytes type = 1;
-}
-
-
-// Reset bucket properties response - no message defined, just send
-// RpbResetBucketResp
 
 // Module-Function pairs for commit hooks and other bucket properties
 // that take functions

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -120,8 +120,6 @@ msg_type(28) -> rpbsearchqueryresp;
 msg_type(29) -> rpbresetbucketreq;
 msg_type(30) -> rpbresetbucketresp;
 msg_type(31) -> rpbgetbuckettypereq;
-msg_type(32) -> rpbsetbuckettypereq;
-msg_type(33) -> rpbresetbuckettypereq;
 msg_type(40) -> rpbcsbucketreq;
 msg_type(41) -> rpbcsbucketresp;
 msg_type(50) -> rpbcounterupdatereq;
@@ -180,8 +178,6 @@ msg_code(rpbsearchqueryresp)     -> 28;
 msg_code(rpbresetbucketreq)      -> 29;
 msg_code(rpbresetbucketresp)     -> 30;
 msg_code(rpbgetbuckettypereq)    -> 31;
-msg_code(rpbsetbuckettypereq)    -> 32;
-msg_code(rpbresetbuckettypereq)  -> 33;
 msg_code(rpbcsbucketreq)         -> 40;
 msg_code(rpbcsbucketresp)        -> 41;
 msg_code(rpbcounterupdatereq)    -> 50;
@@ -210,8 +206,7 @@ decoder_for(N) when N >= 0, N < 3;
                     N == 7; N == 8;
                     (N >= 19 andalso N =< 22);
                     N == 29; N == 30;
-                    N == 31; N == 32;
-                    N == 33; N >= 253 ->
+                    N == 31; N >= 253 ->
     riak_pb;
 decoder_for(N) when N >= 3, N < 7;
                     N >= 9, N =< 26;


### PR DESCRIPTION
This is controversial, but I believe clients should be able to either
create AND update bucket types, or not at all. The latter is easier to
reason about, and doesn't open us up to additional security challenges.

Related PRs for riak_api and riak_kv are forthcoming.
