### PR TITLE
Add 2i sort option

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -180,6 +180,8 @@ message RpbIndexReq {
     optional uint32 timeout = 11;
     optional bytes type = 12;         // Bucket type, if not set we assume the 'default' type
     optional bytes term_regex = 13;
+    // Whether to use pagination sort for non-paginated queries
+    optional bool pagination_sort = 14;
 }
 
 // Secondary Index query response


### PR DESCRIPTION
2i sort false by default

This is part of the fix for https://github.com/basho/riak_kv/pull/671

We have to be careful of when to merge this PR, as there will be soon releases on the 2.0 and 1.4 series. This change could possibly make it to the 1.4 series first.
