### PR TITLE
Renaming yz_index to search_index

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -155,7 +155,7 @@ message RpbBucketProps {
     }
     optional RpbReplMode repl = 24;
 
-    optional bytes yz_index = 25;
+    optional bytes search_index = 25;
 }
 
 // Authentication request

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -306,7 +306,7 @@ decode_bucket_props(#rpbbucketprops{n_val=N,
                                     backend=Backend,
                                     search=Search,
                                     repl=Repl,
-                                    yz_index=Index
+                                    search_index=Index
                                    }) ->
     %% Extract numerical properties
     [ {P,V} || {P,V} <- [ {n_val, N}, {old_vclock, Old}, {young_vclock, Young},
@@ -341,7 +341,7 @@ decode_bucket_props(#rpbbucketprops{n_val=N,
     [ {repl, decode_repl(Repl)} || Repl /= undefined ] ++
 
     %% Yokozuna index
-    [ {yz_index, Index} || is_binary(Index) ].
+    [ {search_index, Index} || is_binary(Index) ].
 
 
 
@@ -401,8 +401,8 @@ encode_bucket_props([{search, S}|Rest], Pb) ->
     encode_bucket_props(Rest, Pb#rpbbucketprops{search = encode_bool(S)});
 encode_bucket_props([{repl, Atom}|Rest], Pb) ->
     encode_bucket_props(Rest, Pb#rpbbucketprops{repl = encode_repl(Atom)});
-encode_bucket_props([{yz_index, B}|Rest], Pb) ->
-    encode_bucket_props(Rest, Pb#rpbbucketprops{yz_index = to_binary(B)});
+encode_bucket_props([{search_index, B}|Rest], Pb) ->
+    encode_bucket_props(Rest, Pb#rpbbucketprops{search_index = to_binary(B)});
 encode_bucket_props([_Ignore|Rest], Pb) ->
     %% Ignore any properties not explicitly part of the PB message
     encode_bucket_props(Rest, Pb).


### PR DESCRIPTION
All public facing cases of the term `yokozuna` or `yz` are being renamed to search basho/yokozuna#235, including renaming the `yz_index` bucket type to `search_index`.
