### PR TITLE
Add 2i term regex filter to 1.4 branch

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -173,6 +173,8 @@ message RpbIndexReq {
     optional uint32 max_results = 9;
     optional bytes continuation = 10;
     optional uint32 timeout = 11;
+    optional bytes unused = 12;
+    optional bytes term_regex = 13;
 }
 
 // Secondary Index query response

--- a/src/riak_pb.app.src
+++ b/src/riak_pb.app.src
@@ -1,7 +1,7 @@
 {application, riak_pb,
  [
   {description, "Riak Protocol Buffers Messages"},
-  {vsn, "1.4.1.2"},
+  {vsn, git},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
Also use git in riak_pb.app.src like in develop.
This way there is one less place to change for new versions.

/cc @seancribbs 

I just wanted to run this very simple change by you. I'm adding term_regex and an unused field to pad where bucket types will be.  I thought this way anything out there in the wild would be compatible. Even though the field has not been added in an official release, it's better to be safe. What do you think?
