### PR TITLE
Inital pass at generating Protocol Buffer headers/source for C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist/*.egg
 
 # Java
 target/*
+
+# C
+c/*

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,10 @@ PROTOC	 = protoc-c
 PROTOS	:= $(wildcard src/*.proto)
 C_DIR	 = c
 C_FILES	:= $(patsubst src/%.proto,$(C_DIR)/%.pb-c.c,$(PROTOS))
+H_FILES	:= $(patsubst src/%.proto,$(C_DIR)/%.pb-c.h,$(PROTOS))
 C_PREFIX := /usr/local/riak_pb_c
 
-c_compile: c_announce c_protoc_check $(C_DIR) $(C_FILES)
+c_compile: c_announce c_protoc_check $(C_DIR) $(C_FILES) $(H_FILES)
 
 c_announce:
 	@echo "==> C (compile)"


### PR DESCRIPTION
Here is a basic attempt to generate C header and source file from .proto files.

**Note:** This now requires the protoc-c package

Currently `c_release` does nothing, but in the future could install into a configurable location, such as `/usr/local`
