### PR TITLE
Resolves issue with maven >= 3.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.twdata.maven</groupId>
+                        <artifactId>mojo-executor</artifactId>
+                        <version>2.2.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The problem is caused by the plugin using an old version of a  dependency
which I've overriden in our POM. This will now work with maven 3.1.x and 3.2.x.

Also submitting a PR to the plugin repo to bump the dependency version.

Fixes #83
