### PR TITLE
Add missing 'consistent' bucket(-type) property.

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -151,6 +151,9 @@ message RpbBucketProps {
 
     // KV Datatypes
     optional bytes datatype = 26;
+
+    // KV strong consistency
+    optional bool consistent = 27;
 }
 
 // Authentication request

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -180,7 +180,8 @@ decode_bucket_props(#rpbbucketprops{n_val=N,
                                     search=Search,
                                     repl=Repl,
                                     search_index=Index,
-                                    datatype=Datatype
+                                    datatype=Datatype,
+                                    consistent=Consistent
                                    }) ->
     %% Extract numerical properties
     [ {P,V} || {P,V} <- [ {n_val, N}, {old_vclock, Old}, {young_vclock, Young},
@@ -190,7 +191,7 @@ decode_bucket_props(#rpbbucketprops{n_val=N,
     [ {BProp, decode_bool(Bool)} ||
        {BProp, Bool} <- [{allow_mult, AM}, {last_write_wins, LWW},
                          {basic_quorum, BQ}, {notfound_ok, NFOK},
-                         {search, Search}],
+                         {search, Search}, {consistent, Consistent}],
         Bool /= undefined ] ++
 
     %% Extract commit hooks
@@ -280,6 +281,8 @@ encode_bucket_props([{search_index, B}|Rest], Pb) ->
     encode_bucket_props(Rest, Pb#rpbbucketprops{search_index = to_binary(B)});
 encode_bucket_props([{datatype, D}|Rest], Pb) ->
     encode_bucket_props(Rest, Pb#rpbbucketprops{datatype = to_binary(D)});
+encode_bucket_props([{consistent, S}|Rest], Pb) ->
+    encode_bucket_props(Rest, Pb#rpbbucketprops{consistent = encode_bool(S)});
 encode_bucket_props([_Ignore|Rest], Pb) ->
     %% Ignore any properties not explicitly part of the PB message
     encode_bucket_props(Rest, Pb).

--- a/test/bucket_props_codec_eqc.erl
+++ b/test/bucket_props_codec_eqc.erl
@@ -92,7 +92,8 @@ bucket_prop() ->
            flag(search),
            repl(),
            yz_index(),
-           datatype()]).
+           datatype(),
+           flag(consistent)]).
 
 sortuniq(Gen) ->
     ?LET(L, Gen, lists:ukeysort(1,L)).


### PR DESCRIPTION
Discovered when testing Python client; property was not exposed via PB.
