### PR TITLE
Convert Erlang build steps to tools.mk.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc/*
 .eqc-info
 current_counterexample.eqc
 src/riak_pb_messages.erl
+.local_dialyzer_plt
 
 # Python
 riak_pb.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: deps
 
-all: deps compile
+all: deps compile_all
 
 deps: erl_deps
 
-compile: erl_compile python_compile java_compile c_compile
+compile_all: erl_compile python_compile java_compile c_compile
 
 clean: erl_clean python_clean java_clean c_clean
 
@@ -13,49 +13,20 @@ distclean: clean
 
 release: python_release java_release c_release
 
-test: erl_test
-
 # Erlang-specific build steps
+DIALYZER_APPS = kernel stdlib erts crypto compiler hipe syntax_tools
+include tools.mk
+
 erl_deps:
-	@./rebar get-deps
+	@${REBAR} get-deps
 
 erl_compile:
-	@./rebar compile
+	@${REBAR} compile
 
 erl_clean:
-	@./rebar clean
+	@${REBAR} clean
 
-erl_test: erl_compile
-	@./rebar eunit skip_deps=true
-
-REPO = riak_pb
-APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
-	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
-COMBO_PLT = $(HOME)/.$(REPO)_combo_dialyzer_plt
-
-check_plt: erl_deps erl_compile
-	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS) \
-		deps/*/ebin
-
-build_plt: erl_deps erl_compile
-	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS) \
-		deps/*/ebin
-
-dialyzer: erl_deps erl_compile
-	@echo
-	@echo Use "'make check_plt'" to check PLT prior to using this target.
-	@echo Use "'make build_plt'" to build PLT prior to using this target.
-	@echo
-	@sleep 1
-	dialyzer -Wno_return --plt $(COMBO_PLT) deps/*/ebin
-
-cleanplt:
-	@echo
-	@echo "Are you sure?  It could take a long time to rebuild."
-	@echo Deleting $(COMBO_PLT) in 5 seconds.
-	@echo
-	sleep 5
-	rm $(COMBO_PLT)
+compile: erl_compile # Hack for tools.mk
 
 # Python specific build steps
 python_compile:

--- a/tools.mk
+++ b/tools.mk
@@ -1,0 +1,68 @@
+REBAR ?= ./rebar
+
+compile-no-deps:
+	${REBAR} compile skip_deps=true
+
+test: compile
+	${REBAR} eunit skip_deps=true
+
+docs:
+	${REBAR} doc skip_deps=true
+
+xref: compile
+	${REBAR} xref skip_deps=true
+
+PLT ?= $(HOME)/.combo_dialyzer_plt
+LOCAL_PLT = .local_dialyzer_plt
+DIALYZER_FLAGS ?= -Wunmatched_returns
+
+${PLT}: compile
+	@if [ -f $(PLT) ]; then \
+		dialyzer --check_plt --plt $(PLT) --apps $(DIALYZER_APPS) && \
+		dialyzer --add_to_plt --plt $(PLT) --output_plt $(PLT) --apps $(DIALYZER_APPS) ; test $$? -ne 1; \
+	else \
+		dialyzer --build_plt --output_plt $(PLT) --apps $(DIALYZER_APPS); test $$? -ne 1; \
+	fi
+
+${LOCAL_PLT}: compile
+	@if [ -d deps ]; then \
+		if [ -f $(LOCAL_PLT) ]; then \
+			dialyzer --check_plt --plt $(LOCAL_PLT) deps/*/ebin  && \
+			dialyzer --add_to_plt --plt $(LOCAL_PLT) --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1; \
+		else \
+			dialyzer --build_plt --output_plt $(LOCAL_PLT) deps/*/ebin ; test $$? -ne 1; \
+		fi \
+	fi
+
+dialyzer-run:
+	@echo "==> $(shell basename $(shell pwd)) (dialyzer)"
+	@if [ -f $(LOCAL_PLT) ]; then \
+		PLTS="$(PLT) $(LOCAL_PLT)"; \
+	else \
+		PLTS=$(PLT); \
+	fi; \
+	if [ -f dialyzer.ignore-warnings ]; then \
+		if [ $$(grep -cvE '[^[:space:]]' dialyzer.ignore-warnings) -ne 0 ]; then \
+			echo "ERROR: dialyzer.ignore-warnings contains a blank/empty line, this will match all messages!"; \
+			exit 1; \
+		fi; \
+		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin > dialyzer_warnings ; \
+		egrep -v "^\s*(done|Checking|Proceeding|Compiling)" dialyzer_warnings | grep -F -f dialyzer.ignore-warnings -v > dialyzer_unhandled_warnings ; \
+		cat dialyzer_unhandled_warnings ; \
+		[ $$(cat dialyzer_unhandled_warnings | wc -l) -eq 0 ] ; \
+	else \
+		dialyzer $(DIALYZER_FLAGS) --plts $${PLTS} -c ebin; \
+	fi
+
+dialyzer-quick: compile-no-deps dialyzer-run
+
+dialyzer: ${PLT} ${LOCAL_PLT} dialyzer-run
+
+cleanplt:
+	@echo
+	@echo "Are you sure?  It takes several minutes to re-build."
+	@echo Deleting $(PLT) and $(LOCAL_PLT) in 5 seconds.
+	@echo
+	sleep 5
+	rm $(PLT)
+	rm $(LOCAL_PLT)


### PR DESCRIPTION
This will help with the automated builds, specifically it adds appropriate `dialyzer` and `xref` targets.

NB: you _should_ see this branch failing. There are lots of dialyzer warnings and xref has not been tuned.
