### PR TITLE
Add a RangeReg - a new top-level datatype

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -62,4 +62,4 @@ riak_yokozuna_pb.erl:221: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can n
 ## Insufficient typing on record in generated code
 riak_pb_codec.erl:338: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
-riak_pb_dt_codec.erl:185: The pattern {AtomType, _} can never match the type 'false'
+riak_pb_dt_codec.erl:187: The pattern {AtomType, _} can never match the type 'false'

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -62,4 +62,4 @@ riak_yokozuna_pb.erl:221: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can n
 ## Insufficient typing on record in generated code
 riak_pb_codec.erl:338: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
-riak_pb_dt_codec.erl:187: The pattern {AtomType, _} can never match the type 'false'
+riak_pb_dt_codec.erl:189: The pattern {AtomType, _} can never match the type 'false'

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -62,4 +62,4 @@ riak_yokozuna_pb.erl:221: The pattern <Types, [{Fnum, Bytes} | Tail], Acc> can n
 ## Insufficient typing on record in generated code
 riak_pb_codec.erl:338: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
-riak_pb_dt_codec.erl:181: The pattern {AtomType, _} can never match the type 'false'
+riak_pb_dt_codec.erl:185: The pattern {AtomType, _} can never match the type 'false'

--- a/src/riak_dt.proto
+++ b/src/riak_dt.proto
@@ -34,10 +34,10 @@ option java_outer_classname = "RiakDtPB";
  */
 
 /*
- * A RangeReg is a register that keeps track of the largest, smallest,
+ * A Range is a register that keeps track of the largest, smallest,
  * first and last values that have been assigned to it.
  */
-message RangeRegEntry {
+message RangeEntry {
     optional sint64 max_value   = 1;
     optional sint64 min_value   = 2;
     optional sint64 first_value = 3;
@@ -60,7 +60,7 @@ message MapField {
         REGISTER = 3;
         FLAG     = 4;
         MAP      = 5;
-        RANGEREG = 6;
+        RANGE    = 6;
     }
 
     required bytes        name = 1;
@@ -79,7 +79,7 @@ message MapEntry {
     optional bytes    register_value = 4;
     optional bool     flag_value     = 5;
     repeated MapEntry map_value      = 6;
-    optional RangeRegEntry rangereg_value = 7;
+    optional RangeEntry range_value  = 7;
 }
 
 /*
@@ -117,10 +117,10 @@ message DtFetchReq {
  * then empty values (sets, maps) should be treated as such.
  */
 message DtValue {
-    optional sint64        counter_value  = 1;
-    repeated bytes         set_value      = 2;
-    repeated MapEntry      map_value      = 3;
-    optional RangeRegEntry rangereg_value = 4;
+    optional sint64     counter_value = 1;
+    repeated bytes      set_value     = 2;
+    repeated MapEntry   map_value     = 3;
+    optional RangeEntry range_value   = 4;
 }
 
 
@@ -135,10 +135,10 @@ message DtValue {
  */
 message DtFetchResp {
     enum DataType {
-        COUNTER  = 1;
-        SET      = 2;
-        MAP      = 3;
-        RANGEREG = 4;
+        COUNTER = 1;
+        SET     = 2;
+        MAP     = 3;
+        RANGE   = 4;
     }
 
     optional bytes    context = 1;
@@ -196,7 +196,7 @@ message MapUpdate {
     optional bytes     register_op = 4;
     optional FlagOp    flag_op     = 5;
     optional MapOp     map_op      = 6;
-    optional sint64    rangereg_op = 7;
+    optional sint64    range_op    = 7;
 }
 
 /*
@@ -227,7 +227,7 @@ message DtOp {
      * which is to assign a new value into it, so the operation is just
      * the new value.
      */
-    optional sint64     rangereg_op = 4;
+    optional sint64     range_op = 4;
 }
 
 /*
@@ -267,12 +267,12 @@ message DtUpdateReq {
  */
 message DtUpdateResp {
     // The key, if assigned by the server
-    optional bytes         key            = 1;
+    optional bytes      key           = 1;
 
     // The opaque update context and value, if return_body was set.
-    optional bytes         context        = 2;
-    optional sint64        counter_value  = 3;
-    repeated bytes         set_value      = 4;
-    repeated MapEntry      map_value      = 5;
-    optional RangeRegEntry rangereg_value = 6;
+    optional bytes      context       = 2;
+    optional sint64     counter_value = 3;
+    repeated bytes      set_value     = 4;
+    repeated MapEntry   map_value     = 5;
+    optional RangeEntry range_value   = 6;
 }

--- a/src/riak_dt.proto
+++ b/src/riak_dt.proto
@@ -34,6 +34,17 @@ option java_outer_classname = "RiakDtPB";
  */
 
 /*
+ * A RangeReg is a register that keeps track of the largest, smallest,
+ * first and last values that have been assigned to it.
+ */
+message RangeRegEntry {
+    optional sint64 max_value   = 1;
+    optional sint64 min_value   = 2;
+    optional sint64 first_value = 3;
+    optional sint64 last_value  = 4;
+}
+
+/*
  * Field names in maps are composed of a binary identifier and a type.
  * This is so that two clients can create fields with the same name
  * but different types, and they converge independently.
@@ -49,6 +60,7 @@ message MapField {
         REGISTER = 3;
         FLAG     = 4;
         MAP      = 5;
+        RANGEREG = 6;
     }
 
     required bytes        name = 1;
@@ -67,17 +79,7 @@ message MapEntry {
     optional bytes    register_value = 4;
     optional bool     flag_value     = 5;
     repeated MapEntry map_value      = 6;
-}
-
-/*
- * A RangeReg is a register that keeps track of the largest, smallest,
- * first and last values that have been assigned to it.
- */
-message RangeRegEntry {
-    optional sint64 max_value   = 1;
-    optional sint64 min_value   = 2;
-    optional sint64 first_value = 3;
-    optional sint64 last_value  = 4;
+    optional RangeRegEntry rangereg_value = 7;
 }
 
 /*
@@ -118,7 +120,7 @@ message DtValue {
     optional sint64        counter_value  = 1;
     repeated bytes         set_value      = 2;
     repeated MapEntry      map_value      = 3;
-    optional RangeRegEntry rangereg_value = 6;
+    optional RangeRegEntry rangereg_value = 4;
 }
 
 
@@ -194,6 +196,7 @@ message MapUpdate {
     optional bytes     register_op = 4;
     optional FlagOp    flag_op     = 5;
     optional MapOp     map_op      = 6;
+    optional sint64    rangereg_op = 7;
 }
 
 /*
@@ -211,14 +214,6 @@ message MapOp {
 }
 
 /*
- * An operation to update a RangeReg. A RangeReg is updated with a single integer,
- * and it keeps it if it's the smallest, largest, first or last value it has seen.
- */
-message RangeRegOp {
-    required sint64 value = 1;
-}
-
-/*
  * A "union" type for update operations. The included operation
  * depends on the datatype being updated.
  */
@@ -226,7 +221,13 @@ message DtOp {
     optional CounterOp  counter_op  = 1;
     optional SetOp      set_op      = 2;
     optional MapOp      map_op      = 3;
-    optional RangeRegOp rangereg_op = 4;
+
+    /*
+     * Like a register in a map, there's only one operation on a rangereg,
+     * which is to assign a new value into it, so the operation is just
+     * the new value.
+     */
+    optional sint64     rangereg_op = 4;
 }
 
 /*

--- a/src/riak_dt.proto
+++ b/src/riak_dt.proto
@@ -70,6 +70,17 @@ message MapEntry {
 }
 
 /*
+ * A RangeReg is a register that keeps track of the largest, smallest,
+ * first and last values that have been assigned to it.
+ */
+message RangeRegEntry {
+    optional sint64 max_value   = 1;
+    optional sint64 min_value   = 2;
+    optional sint64 first_value = 3;
+    optional sint64 last_value  = 4;
+}
+
+/*
  * =============== FETCH =================
  */
 
@@ -104,9 +115,10 @@ message DtFetchReq {
  * then empty values (sets, maps) should be treated as such.
  */
 message DtValue {
-    optional sint64   counter_value = 1;
-    repeated bytes    set_value     = 2;
-    repeated MapEntry map_value     = 3;
+    optional sint64        counter_value  = 1;
+    repeated bytes         set_value      = 2;
+    repeated MapEntry      map_value      = 3;
+    optional RangeRegEntry rangereg_value = 6;
 }
 
 
@@ -121,9 +133,10 @@ message DtValue {
  */
 message DtFetchResp {
     enum DataType {
-        COUNTER = 1;
-        SET     = 2;
-        MAP     = 3;
+        COUNTER  = 1;
+        SET      = 2;
+        MAP      = 3;
+        RANGEREG = 4;
     }
 
     optional bytes    context = 1;
@@ -198,13 +211,22 @@ message MapOp {
 }
 
 /*
+ * An operation to update a RangeReg. A RangeReg is updated with a single integer,
+ * and it keeps it if it's the smallest, largest, first or last value it has seen.
+ */
+message RangeRegOp {
+    required sint64 value = 1;
+}
+
+/*
  * A "union" type for update operations. The included operation
  * depends on the datatype being updated.
  */
 message DtOp {
-    optional CounterOp counter_op = 1;
-    optional SetOp     set_op     = 2;
-    optional MapOp     map_op     = 3;
+    optional CounterOp  counter_op  = 1;
+    optional SetOp      set_op      = 2;
+    optional MapOp      map_op      = 3;
+    optional RangeRegOp rangereg_op = 4;
 }
 
 /*
@@ -244,11 +266,12 @@ message DtUpdateReq {
  */
 message DtUpdateResp {
     // The key, if assigned by the server
-    optional bytes    key           = 1;
+    optional bytes         key            = 1;
 
     // The opaque update context and value, if return_body was set.
-    optional bytes    context       = 2;
-    optional sint64   counter_value = 3;
-    repeated bytes    set_value     = 4;
-    repeated MapEntry map_value     = 5;
+    optional bytes         context        = 2;
+    optional sint64        counter_value  = 3;
+    repeated bytes         set_value      = 4;
+    repeated MapEntry      map_value      = 5;
+    optional RangeRegEntry rangereg_value = 6;
 }

--- a/src/riak_pb_dt_codec.erl
+++ b/src/riak_pb_dt_codec.erl
@@ -131,6 +131,8 @@ decode_map_entry(#mapentry{field=#mapfield{type='REGISTER'}=Field, register_valu
     {decode_map_field(Field, Mods), Val};
 decode_map_entry(#mapentry{field=#mapfield{type='FLAG'}=Field, flag_value=Val}, Mods) ->
     {decode_map_field(Field, Mods), Val};
+decode_map_entry(#mapentry{field=#mapfield{type='RANGEREG'}=Field, rangereg_value=Val}, Mods) ->
+    {decode_map_field(Field, Mods), decode_rangereg_entry(Val)};
 decode_map_entry(#mapentry{field=#mapfield{type='MAP'}=Field, map_value=Val}, Mods) ->
     {decode_map_field(Field, Mods), [ decode_map_entry(Entry, Mods) || Entry <- Val ]}.
 

--- a/src/riak_pb_dt_codec.erl
+++ b/src/riak_pb_dt_codec.erl
@@ -49,17 +49,19 @@
 -type counter_value() :: integer().
 -type set_value() :: [ binary() ].
 -type register_value() :: binary().
+-type rangereg_value() :: [{atom(), integer()}].
 -type flag_value() :: boolean().
 -type map_entry() :: {map_field(), embedded_value()}.
 -type map_field() :: {binary(), embedded_type()}.
 -type map_value() :: [ map_entry() ].
 -type embedded_value() :: counter_value() | set_value() | register_value() | flag_value() | map_value().
--type toplevel_value() :: counter_value() | set_value() | map_value() | undefined.
+-type toplevel_value() :: counter_value() | set_value() | map_value() | rangereg_value() | undefined.
 -type fetch_response() :: {toplevel_type(), toplevel_value(), context()}.
 
 %% Type names as atoms
 -type embedded_type() :: counter | set | register | flag | map.
--type toplevel_type() :: counter | set | map.
+-type toplevel_type() :: counter | set | map | rangereg.
+-type all_type()      :: toplevel_type() | embedded_type().
 
 %% Operations
 -type counter_op() :: increment | decrement | {increment | decrement, integer()}.
@@ -67,10 +69,11 @@
 -type set_op() :: simple_set_op() | {update, [simple_set_op()]}.
 -type flag_op() :: enable | disable.
 -type register_op() :: {assign, binary()}.
+-type rangereg_op() :: {assign, integer()}.
 -type simple_map_op() :: {remove, map_field()} | {update, map_field(), embedded_type_op()}.
 -type map_op() :: simple_map_op() | {update, [simple_map_op()]}.
 -type embedded_type_op() :: counter_op() | set_op() | register_op() | flag_op() | map_op().
--type toplevel_op() :: counter_op() | set_op() | map_op().
+-type toplevel_op() :: counter_op() | set_op() | map_op() | rangereg_op().
 -type update() :: {toplevel_type(), toplevel_op(), context()}.
 
 %% Request options
@@ -89,7 +92,7 @@
                      include_context | {include_context, boolean()}.
 
 %% Server-side type<->module mappings
--type type_mappings() :: [{embedded_type(), module()}].
+-type type_mappings() :: [{all_type(), module()}].
 
 
 %% =========================
@@ -166,10 +169,11 @@ decode_type(PBType, Mods) ->
     proplists:get_value(AtomType, Mods, AtomType).
 
 %% @doc Decodes a PB message type name into an atom.
--spec decode_type(atom()) -> atom().
+-spec decode_type(atom()) -> all_type().
 decode_type('COUNTER')  -> counter;
 decode_type('SET')      -> set;
 decode_type('REGISTER') -> register;
+decode_type('RANGEREG') -> rangereg;
 decode_type('FLAG')     -> flag;
 decode_type('MAP')      -> map.
 
@@ -185,10 +189,11 @@ encode_type(TypeOrMod, Mods) ->
     end.
 
 %% @doc Encodes an atom type name into the PB message equivalent.
--spec encode_type(atom()) -> atom().
+-spec encode_type(all_type()) -> atom().
 encode_type(counter)  -> 'COUNTER';
 encode_type(set)      -> 'SET';
 encode_type(register) -> 'REGISTER';
+encode_type(rangereg) -> 'RANGEREG';
 encode_type(flag)     -> 'FLAG';
 encode_type(map)      -> 'MAP'.
 
@@ -196,6 +201,29 @@ encode_type(map)      -> 'MAP'.
 encode_flag_value(on) -> true;
 encode_flag_value(off) -> false;
 encode_flag_value(Other) -> Other.
+
+encode_rangereg_entry(Value) -> encode_rangereg_entry(#rangeregentry{}, Value).
+
+encode_rangereg_entry(Entry, []) -> Entry;
+encode_rangereg_entry(Entry, [{max, Value} | Tail]) ->
+    encode_rangereg_entry(Entry#rangeregentry{max_value=Value}, Tail);
+encode_rangereg_entry(Entry, [{min, Value} | Tail]) ->
+    encode_rangereg_entry(Entry#rangeregentry{min_value=Value}, Tail);
+encode_rangereg_entry(Entry, [{first, Value} | Tail]) ->
+    encode_rangereg_entry(Entry#rangeregentry{first_value=Value}, Tail);
+encode_rangereg_entry(Entry, [{last, Value} | Tail]) ->
+    encode_rangereg_entry(Entry#rangeregentry{last_value=Value}, Tail);
+encode_rangereg_entry(Entry, [_|Tail]) ->
+    encode_rangereg_entry(Tail, Entry).
+
+decode_rangereg_entry(RRE) ->
+    [
+     {max,   RRE#rangeregentry.max_value},
+     {min,   RRE#rangeregentry.min_value},
+     {first, RRE#rangeregentry.first_value},
+     {last,  RRE#rangeregentry.last_value}
+    ].
+
 
 %% ========================
 %% FETCH REQUEST / RESPONSE
@@ -254,7 +282,11 @@ decode_fetch_response(#dtfetchresp{context=Context, type='SET',
     {set, Val, Context};
 decode_fetch_response(#dtfetchresp{context=Context, type='MAP',
                                    value=#dtvalue{map_value=Val}}) ->
-    {map, [ decode_map_entry(Entry) || Entry <- Val ], Context}.
+    {map, [ decode_map_entry(Entry) || Entry <- Val ], Context};
+decode_fetch_response(#dtfetchresp{context=Context, type='RANGEREG',
+                                   value=#dtvalue{rangereg_value=Val}}) ->
+    {rangereg, decode_rangereg_entry(Val), Context}.
+
 
 %% @doc Encodes the result of a fetch request into a FetchResponse message.
 -spec encode_fetch_response(toplevel_type(), toplevel_value(), context()) -> #dtfetchresp{}.
@@ -273,7 +305,9 @@ encode_fetch_response(Type, Value, Context, Mods) ->
         set ->
             Response#dtfetchresp{value=#dtvalue{set_value=Value}};
         map ->
-            Response#dtfetchresp{value=#dtvalue{map_value=[encode_map_entry(Entry, Mods) || Entry <- Value]}}
+            Response#dtfetchresp{value=#dtvalue{map_value=[encode_map_entry(Entry, Mods) || Entry <- Value]}};
+        rangereg ->
+            Response#dtfetchresp{value=#dtvalue{rangereg_value=encode_rangereg_entry(Value)}}
     end.
 
 %% =========================
@@ -326,15 +360,21 @@ encode_set_update({remove, Member}, #setop{removes=R}=S) when is_binary(Member) 
 encode_set_update({remove_all, Members}, #setop{removes=R}=S) when is_list(Members) ->
     S#setop{removes=Members++R}.
 
+-spec decode_rangereg_op(#rangeregop{}) -> rangereg_op().
+decode_rangereg_op(#rangeregop{value=Value}) ->
+    {assign, Value}.
+
+-spec encode_rangereg_op(rangereg_op()) -> #rangeregop{}.
+encode_rangereg_op({assign, Value}) ->
+    #rangeregop{value=Value}.
 
 %% @doc Decodes a operation name from a PB message into an atom.
--spec decode_flag_op(atom()) -> atom().
-
+-spec decode_flag_op(atom()) -> flag_op().
 decode_flag_op('ENABLE')  -> enable;
 decode_flag_op('DISABLE') -> disable.
 
 %% @doc Encodes an atom operation name into the PB message equivalent.
--spec encode_flag_op(atom()) -> atom().
+-spec encode_flag_op(flag_op()) -> atom().
 encode_flag_op(enable)  -> 'ENABLE';
 encode_flag_op(disable) -> 'DISABLE'.
 
@@ -413,7 +453,12 @@ decode_operation(#dtop{counter_op=#counterop{}=Op}, _) ->
 decode_operation(#dtop{set_op=#setop{}=Op}, _) ->
     decode_set_op(Op);
 decode_operation(#dtop{map_op=#mapop{}=Op}, Mods) ->
-    decode_map_op(Op, Mods).
+    decode_map_op(Op, Mods);
+decode_operation(#dtop{rangereg_op=#rangeregop{}=Op}, _) ->
+    decode_rangereg_op(Op).
+
+
+
 
 %% @doc Encodes a datatype-specific operation into a DtOperation message.
 -spec encode_operation(toplevel_op(), toplevel_type()) -> #dtop{}.
@@ -422,7 +467,9 @@ encode_operation(Op, counter) ->
 encode_operation(Op, set) ->
     #dtop{set_op=encode_set_op(Op)};
 encode_operation(Op, map) ->
-    #dtop{map_op=encode_map_op(Op)}.
+    #dtop{map_op=encode_map_op(Op)};
+encode_operation(Op, rangereg) ->
+    #dtop{rangereg_op=encode_rangereg_op(Op)}.
 
 %% @doc Returns the type that the DtOp message expects to be performed
 %% on.
@@ -432,7 +479,9 @@ operation_type(#dtop{counter_op=#counterop{}}) ->
 operation_type(#dtop{set_op=#setop{}}) ->
     set;
 operation_type(#dtop{map_op=#mapop{}}) ->
-    map.
+    map;
+operation_type(#dtop{rangereg_op=#rangeregop{}}) ->
+    rangereg.
 
 %% @doc Encodes an update request into a DtUpdate message.
 -spec encode_update_request({binary(), binary()}, binary() | undefined, update()) -> #dtupdatereq{}.


### PR DESCRIPTION
Rangereg is a register for integers that tracks the largest,
the smallest, the first (by timestamp) and the last (by timestamp)
integers assigned into it.

This is part of the changes in basho/riak_kv#1005 .
