### PR TITLE
getting current_command with both newer and older rebar versions

### DIFF
--- a/plugins/riak_pb_msgcodegen.erl
+++ b/plugins/riak_pb_msgcodegen.erl
@@ -25,7 +25,9 @@
 %% Public API
 %% ===================================================================
 preprocess(Config, _AppFile) ->
-    case rebar_config:get(Config, current_command, undefined) of
+    CurrentCommand = rebar_config:get(Config, current_command,
+                      rebar_config:get_xconf(Config, current_command, undefined)),
+    case CurrentCommand of
         'compile' ->
             case rebar_utils:find_files("src", ".*\\.csv") of
                 [] ->


### PR DESCRIPTION
At some point rebar made `current_command` available through `rebar_config:get_xconf` instead of `rebar_config:get`. This resulted in behaviour discussed at https://github.com/basho/riak-erlang-client/issues/151 when building anything that depends on riak-erlang-client with newer rebar versions.

This commit fixes it without loosing compatibility with older rebar versions.
