### PR TITLE
Add Bucket types API

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -98,12 +98,6 @@ message RpbActivateBucketTypeReq {
     required bytes type = 1;
 }
 
-// Set bucket properties response - no message defined, just send
-// RpbSetBucketResp
-
-// Set bucket properties response - no message defined, just send
-// RpbSetBucketResp
-
 // Module-Function pairs for commit hooks and other bucket properties
 // that take functions
 message RpbModFun {

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -98,20 +98,8 @@ message RpbActivateBucketTypeReq {
     required bytes type = 1;
 }
 
-// Activate bucket type request
-message RpbListBucketTypeReq {
-}
-
-// Activate bucket type request
-message RpbStatusBucketTypeReq {
-    required bytes type = 1;
-}
-
-// Activate bucket type request
-message RpbUpdateBucketTypeReq {
-    required bytes type = 1;
-    required RpbBucketProps props = 2;
-}
+// Set bucket properties response - no message defined, just send
+// RpbSetBucketResp
 
 // Set bucket properties response - no message defined, just send
 // RpbSetBucketResp

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -87,6 +87,32 @@ message RpbSetBucketTypeReq {
     required RpbBucketProps props = 2;
 }
 
+// Create bucket type request
+message RpbCreateBucketTypeReq {
+    required bytes type = 1;
+    optional RpbBucketProps props = 2;
+}
+
+// Activate bucket type request
+message RpbActivateBucketTypeReq {
+    required bytes type = 1;
+}
+
+// Activate bucket type request
+message RpbListBucketTypeReq {
+}
+
+// Activate bucket type request
+message RpbStatusBucketTypeReq {
+    required bytes type = 1;
+}
+
+// Activate bucket type request
+message RpbUpdateBucketTypeReq {
+    required bytes type = 1;
+    required RpbBucketProps props = 2;
+}
+
 // Set bucket properties response - no message defined, just send
 // RpbSetBucketResp
 

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -35,9 +35,6 @@
 34,RpbGetBucketKeyPreflistResp,riak_kv
 35,RpbCreateBucketTypeReq,riak_kv
 36,RpbActivateBucketTypeReq,riak_kv
-37,RpbListBucketTypeReq,riak_kv
-38,RpbStatusBucketTypeReq,riak_kv
-39,RpbUpdateBucketTypeReq,riak_kv
 40,RpbCSBucketReq,riak_kv
 41,RpbCSBucketResp,riak_kv
 50,RpbCounterUpdateReq,riak_kv

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -34,7 +34,9 @@
 33,RpbGetBucketKeyPreflistReq,riak_kv
 34,RpbGetBucketKeyPreflistResp,riak_kv
 35,RpbCreateBucketTypeReq,riak_kv
-36,RpbActivateBucketTypeReq,riak_kv
+36,RpbCreateBucketTypeResp,riak_kv
+37,RpbActivateBucketTypeReq,riak_kv
+38,RpbActivateBucketTypeResp,riak_kv
 40,RpbCSBucketReq,riak_kv
 41,RpbCSBucketResp,riak_kv
 50,RpbCounterUpdateReq,riak_kv

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -33,6 +33,11 @@
 32,RpbSetBucketTypeReq,riak
 33,RpbGetBucketKeyPreflistReq,riak_kv
 34,RpbGetBucketKeyPreflistResp,riak_kv
+35,RpbCreateBucketTypeReq,riak_kv
+36,RpbActivateBucketTypeReq,riak_kv
+37,RpbListBucketTypeReq,riak_kv
+38,RpbStatusBucketTypeReq,riak_kv
+39,RpbUpdateBucketTypeReq,riak_kv
 40,RpbCSBucketReq,riak_kv
 41,RpbCSBucketResp,riak_kv
 50,RpbCounterUpdateReq,riak_kv


### PR DESCRIPTION
Add support for create and activate bucket types with riak-erlang-client
riakc_pb_socket:create_bucket_type(Pid, BucketType, BucketProps)
riakc_pb_socket:activate_bucket_type(Pid, BucketType)

Created to be used by sumo_db
https://github.com/basho/riak_kv/issues/1123