### PR TITLE
Revert "* add optional timeout parameter to RpbYokozunaIndexPutReq"

### DIFF
--- a/src/riak_yokozuna.proto
+++ b/src/riak_yokozuna.proto
@@ -49,7 +49,6 @@ message RpbYokozunaIndexGetResp {
 // PUT request - Create a new index
 message RpbYokozunaIndexPutReq {
     required RpbYokozunaIndex index  =  1;
-    optional uint32 timeout          =  2; // Timeout value
 }
 
 // DELETE request - Remove an index


### PR DESCRIPTION
This reverts commit 0ada3b313aa19353d60b1ff677540abf57a8da30.

This is being reverted to work with version 2.0.6, as we don't want pb changes in between minor versions.