### PR TITLE
Revert "Merge pull request #117 from basho/backport/zl/riak-pb-112"

### DIFF
--- a/src/riak_yokozuna.proto
+++ b/src/riak_yokozuna.proto
@@ -49,7 +49,6 @@ message RpbYokozunaIndexGetResp {
 // PUT request - Create a new index
 message RpbYokozunaIndexPutReq {
     required RpbYokozunaIndex index  =  1;
-    optional uint32 timeout          =  2; // Timeout value
 }
 
 // DELETE request - Remove an index


### PR DESCRIPTION
This reverts commit b32976c272e6546036d442a78b71919bfbcc6fa2, reversing
changes made to 818e787d8a7dde97a81658d10c6de47f4e13265d.

This is being reverted to work with version 2.0.6, as we don't want pb changes in between minor versions.