### PR TITLE
Keep the protobuf library limited to 2.5.0, for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ install_requires = ["six >= 1.8.0"]
 requires = ["six(>=1.8.0)"]
 if platform.python_version() < '3.0':
     name = 'riak_pb'
-    requires.append('protobuf(>=2.4.1,<2.7.0)')
-    install_requires.append('protobuf >=2.4.1, <2.7.0')
+    requires.append('protobuf(>=2.4.1,<2.6.0)')
+    install_requires.append('protobuf >=2.4.1, <2.6.0')
 else:
     name = 'python3_riak_pb'
     requires.append('python3_protobuf(>=2.4.1,<2.6.0)')


### PR DESCRIPTION
Since we are limited to protobuf 2.5.0, let's keep that limit the same across all versions of Python.