### PR TITLE
add TsKeyCell for interpolation cells

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -320,7 +320,12 @@ message TsPutResp {
 
 message TsInterpolation {
   required bytes base = 1;
-  repeated RpbPair interpolations = 2;
+  repeated TsKeyCell interpolations = 2;
+}
+
+message TsKeyCell {
+  required bytes key = 1;
+  required TsCell value = 2;
 }
 
 enum TsColumnType {


### PR DESCRIPTION
Change interpolations from using an untyped `binary` element to hold values to a `TsCell` element with more flexible de-serialization characteristics, that doesn't require parsing :sunglasses: 
# THIS BREAKS EXISTING TIME SERIES CLIENTS

But we gotta do it!
