### PR TITLE
don't reverse order of records when preparing data for put

### DIFF
--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -94,7 +94,7 @@ row_for([], SerializedCells) ->
     #tsrow{cells = lists:reverse(SerializedCells)};
 row_for([Datum|RemainingCells], SerializedCells) ->
     row_for(RemainingCells,
-            [cell_for(Datum) | SerializedCells]).
+            lists:append(SerializedCells, [cell_for(Datum)])).
 
 -spec cell_for(ldbvalue()) -> #tscell{}.
 cell_for(Measure) when is_binary(Measure) ->


### PR DESCRIPTION
RTS-421.

Doing so leads to records being laid backwards on the metal and breaks some optimizations in leveldb which assume the un-reversed order.

There is a corresponding fix in riak_kv (https://github.com/basho/riak_kv/pull/1234) that avoids the second reversal, via similar prepending new elements to a list of already collected ones, the net effect of which is the correct order the client eventually sees on fetch.