### PR TITLE
support empty tscells

### DIFF
--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -177,7 +177,8 @@ decode_cells([#tscell{binary_value    = Bin,
                       timestamp_value = undefined,
                       boolean_value   = undefined,
                       set_value       = [],
-                      map_value       = undefined} | T], Acc) ->
+                      map_value       = undefined} | T], Acc)
+  when is_binary(Bin) ->
     decode_cells(T, [Bin | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = Int,
@@ -185,7 +186,8 @@ decode_cells([#tscell{binary_value    = undefined,
                       timestamp_value = undefined,
                       boolean_value   = undefined,
                       set_value       = [],
-                      map_value       = undefined} | T], Acc) ->
+                      map_value       = undefined} | T], Acc)
+  when is_integer(Int) ->
     decode_cells(T, [Int | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
@@ -193,7 +195,8 @@ decode_cells([#tscell{binary_value    = undefined,
                       timestamp_value = undefined,
                       boolean_value   = undefined,
                       set_value       = [],
-                      map_value       = undefined} | T], Acc) ->
+                      map_value       = undefined} | T], Acc)
+  when is_binary(Num)->
     decode_cells(T, [decode_numeric(Num) | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
@@ -201,16 +204,25 @@ decode_cells([#tscell{binary_value    = undefined,
                       timestamp_value = Timestamp,
                       boolean_value   = undefined,
                       set_value       = [],
-                      map_value       = undefined} | T], Acc) ->
+                      map_value       = undefined} | T], Acc)
+  when is_integer(Timestamp)->
     decode_cells(T, [Timestamp | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
                       numeric_value   = undefined,
                       timestamp_value = undefined,
-                      boolean_value   = Bool,
+                      boolean_value   = true,
                       set_value       = [],
                       map_value       = undefined} | T], Acc) ->
-    decode_cells(T, [Bool | Acc]);
+    decode_cells(T, [true | Acc]);
+decode_cells([#tscell{binary_value    = undefined,
+                      integer_value   = undefined,
+                      numeric_value   = undefined,
+                      timestamp_value = undefined,
+                      boolean_value   = false,
+                      set_value       = [],
+                      map_value       = undefined} | T], Acc) ->
+    decode_cells(T, [false | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
                       numeric_value   = undefined,
@@ -236,4 +248,4 @@ decode_cells([#tscell{binary_value    = undefined,
                       boolean_value    = undefined,
                       set_value        = [],
                       map_value        = undefined} | T], Acc) ->
-    decode_cells(T, [undefined | Acc]).
+    decode_cells(T, [[] | Acc]).

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -240,7 +240,7 @@ decode_cells([#tscell{binary_value    = undefined,
                       map_value       = undefined,
                       float_value     = undefined,
                       double_value    = undefined} | T], Acc) ->
-    decode_cells(T, [Bool | Acc]);
+    decode_cells(T, [false | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
                       numeric_value   = undefined,
@@ -284,4 +284,14 @@ decode_cells([#tscell{binary_value    = undefined,
                       float_value     = undefined,
                       double_value    = Double} | T], Acc)
   when is_float(Double) ->
-    decode_cells(T, [Double | Acc]).
+    decode_cells(T, [Double | Acc]);
+decode_cells([#tscell{binary_value    = undefined,
+                      integer_value   = undefined,
+                      numeric_value   = undefined,
+                      timestamp_value = undefined,
+                      boolean_value   = undefined,
+                      set_value       = [],
+                      map_value       = undefined,
+                      float_value     = undefined,
+                      double_value    = undefined} | T], Acc) ->
+    decode_cells(T, [[] | Acc]).

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -230,7 +230,7 @@ decode_cells([#tscell{binary_value    = undefined,
                       boolean_value   = undefined,
                       set_value       = Set,
                       map_value       = undefined} | T], Acc)
-  when is_list(Set) ->
+  when length(Set) > 0 ->
     decode_cells(T, [Set | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -119,7 +119,9 @@ cell_for(Measure) when is_list(Measure) andalso length(Measure) > 0 andalso
                        is_tuple(hd(Measure)) andalso size(hd(Measure)) == 2 ->
     #tscell{map_value = Measure};
 cell_for(Measure) when is_list(Measure) ->
-    #tscell{set_value = Measure}.
+    #tscell{set_value = Measure};
+cell_for(undefined) ->
+    #tscell{}.
 
 -spec decode_rows([#tsrow{}]) -> [tsrow()].
 decode_rows(Rows) ->
@@ -180,7 +182,8 @@ decode_cells([#tscell{binary_value    = undefined,
                       timestamp_value = undefined,
                       boolean_value   = undefined,
                       set_value       = Set,
-                      map_value       = undefined} | T], Acc) ->
+                      map_value       = undefined} | T], Acc)
+  when is_list(Set) ->
     decode_cells(T, [Set | Acc]);
 decode_cells([#tscell{binary_value    = undefined,
                       integer_value   = undefined,
@@ -188,5 +191,14 @@ decode_cells([#tscell{binary_value    = undefined,
                       timestamp_value = undefined,
                       boolean_value   = undefined,
                       set_value       = [],
-                      map_value       = Map} | T], Acc) ->
-    decode_cells(T, [Map | Acc]).
+                      map_value       = Map} | T], Acc)
+  when is_binary(Map) ->
+    decode_cells(T, [Map | Acc]);
+decode_cells([#tscell{binary_value    = undefined,
+                      integer_value    = undefined,
+                      numeric_value    = undefined,
+                      timestamp_value  = undefined,
+                      boolean_value    = undefined,
+                      set_value        = [],
+                      map_value        = undefined} | T], Acc) ->
+    decode_cells(T, [undefined | Acc]).


### PR DESCRIPTION
This adds support for null values in tscells, both encoding and decoding (to work in both client and server).

I haven't made it work yet; there's probably some other bits in riak_kv that it needs to actually handle null values.