### PR TITLE
riak_pb_ts_codec: drop numeric, float, set & map; preserve order in de-/encoding; etc [JIRA: RTS-481]

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -389,14 +389,11 @@ enum TsColumnType {
   FLOAT = 2;
   TIMESTAMP = 3;
   BOOLEAN = 4;
-  SET = 5;
-  MAP = 6;
 }
 
 message TsColumnDescription {
   required bytes name = 1;
   required TsColumnType type = 2;
-  repeated TsColumnType complex_type = 3;
 }
 
 message TsRow {
@@ -406,11 +403,7 @@ message TsRow {
 message TsCell {
   optional bytes binary_value = 1;
   optional sint64 integer_value = 2;
-  optional bytes numeric_value = 3;
-  optional sint64 timestamp_value = 4;
-  optional bool boolean_value = 5;
-  repeated bytes set_value = 6;
-  optional bytes map_value = 7;
-  optional float float_value = 8;
-  optional double double_value = 9;
+  optional sint64 timestamp_value = 3;
+  optional bool boolean_value = 4;
+  optional double double_value = 5;
 }

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -385,8 +385,8 @@ message TsInterpolation {
 
 enum TsColumnType {
   BINARY = 0;
-  INTEGER = 1;
-  FLOAT = 2;
+  SINT64 = 1;
+  DOUBLE = 2;
   TIMESTAMP = 3;
   BOOLEAN = 4;
 }

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -127,12 +127,6 @@ encode_cell(undefined) ->
     #tscell{}.
 
 
--spec decode_rows([#tsrow{}], list(tuple())) -> list(tuple()).
-decode_rows([], Acc) ->
-    lists:reverse(Acc);
-decode_rows([#tsrow{cells = Row} | T], Acc) ->
-    decode_rows(T, [list_to_tuple(decode_cells(Row, [])) | Acc]).
-
 -spec decode_cells([#tscell{}], list(ldbvalue())) -> list(ldbvalue()).
 decode_cells([], Acc) ->
     lists:reverse(Acc);

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -136,14 +136,15 @@ cell_for(Measure) when is_integer(Measure) ->
 cell_for(Measure) when is_float(Measure) ->
     #tscell{double_value = Measure};
 
-cell_for({float, Measure}) ->
-    #tscell{double_value = Measure};
-cell_for({numeric, Measure}) when is_float(Measure) ->
-    #tscell{numeric_value = Measure};
-cell_for({numeric, Measure}) when is_integer(Measure) ->
-    #tscell{numeric_value = Measure};
-cell_for({time, Measure}) ->
-    #tscell{timestamp_value = Measure};
+%% cell_for({float, Measure}) ->
+%%     #tscell{double_value = Measure};
+%% cell_for({numeric, Measure}) when is_float(Measure) ->
+%%     #tscell{double_value = Measure};
+%% cell_for({numeric, Measure}) when ?IS_BIGNUM(Measure) ->
+%%     #tscell{numeric_value = list_to_binary(integer_to_list(Measure))};
+%% cell_for({time, Measure}) ->
+%%     #tscell{timestamp_value = Measure};
+
 cell_for(true) ->
     #tscell{boolean_value = true};
 cell_for(false) ->

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -47,7 +47,7 @@
 -define(SINT64_MIN, -16#8000000000000000).
 -define(SINT64_MAX,  16#7FFFFFFFFFFFFFFF).
 
--define(IS_BIGNUM(X), (is_integer(X) andalso (?SINT64_MIN < X orelse X < ?SINT64_MAX))).
+-define(IS_BIGNUM(X), (is_integer(X) andalso (?SINT64_MIN > X orelse X < ?SINT64_MAX))).
 
 %% types existing between us and eleveldb
 -type ldbvalue() :: binary() | number() | boolean() | list().

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -170,7 +170,10 @@ decode_numeric(Num) ->
     NumList = binary_to_list(Num),
     case string:chr(NumList, $.) of
         0 ->
-            list_to_float(string:concat(NumList, ".0"));
+            try list_to_integer(NumList)
+            catch error:badarg ->
+                    list_to_float(string:concat(NumList, ".0"))
+            end;
         _ ->
             list_to_float(NumList)
     end.

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -130,20 +130,20 @@ row_for([Datum|RemainingCells], SerializedCells) ->
 cell_for(Measure) when is_binary(Measure) ->
     #tscell{binary_value = Measure};
 cell_for(Measure) when ?IS_BIGNUM(Measure)  ->
-    #tscell{numeric_value = list_to_binary(integer_to_list(Measure))};
+    #tscell{numeric_value = integer_to_binary(Measure)};
 cell_for(Measure) when is_integer(Measure) ->
     #tscell{integer_value = Measure};
 cell_for(Measure) when is_float(Measure) ->
     #tscell{double_value = Measure};
 
-%% cell_for({float, Measure}) ->
-%%     #tscell{double_value = Measure};
-%% cell_for({numeric, Measure}) when is_float(Measure) ->
-%%     #tscell{double_value = Measure};
-%% cell_for({numeric, Measure}) when ?IS_BIGNUM(Measure) ->
-%%     #tscell{numeric_value = list_to_binary(integer_to_list(Measure))};
-%% cell_for({time, Measure}) ->
-%%     #tscell{timestamp_value = Measure};
+cell_for({numeric, Measure}) when is_float(Measure) ->
+    #tscell{numeric_value = float_to_binary(Measure)};
+cell_for({numeric, Measure}) when is_integer(Measure) ->
+    #tscell{numeric_value = integer_to_binary(Measure)};
+cell_for({float, Measure}) ->
+    #tscell{double_value = Measure};
+cell_for({time, Measure}) ->
+    #tscell{timestamp_value = Measure};
 
 cell_for(true) ->
     #tscell{boolean_value = true};

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -36,7 +36,6 @@
          encode_rows/1,
          encode_cells/1,
          decode_rows/1,
-         decode_row/1,
          decode_cells/1,
          encode_field_type/1,
          encode_tsdelreq/3,
@@ -94,10 +93,7 @@ decode_cells(Cells) ->
 
 -spec decode_rows([#tsrow{}]) -> [tsrow()].
 decode_rows(Rows) ->
-    decode_row(Rows, []).
-
-decode_row(Row) ->
-    decode_row(Row, []).
+    decode_rows(Rows, []).
 
 encode_tsdelreq(Bucket, Key, Options) ->
     #tsdelreq{table   = Bucket,
@@ -162,11 +158,11 @@ cell_for(undefined) ->
     #tscell{}.
 
 
--spec decode_row([#tsrow{}], list(tuple())) -> [tsrow()].
-decode_row([], Acc) ->
+-spec decode_rows([#tsrow{}], list(tuple())) -> [tsrow()].
+decode_rows([], Acc) ->
     lists:reverse(Acc);
-decode_row([#tsrow{cells = Row} | T], Acc) ->
-    decode_row(T, [list_to_tuple(decode_cells(Row, [])) | Acc]).
+decode_rows([#tsrow{cells = Row} | T], Acc) ->
+    decode_rows(T, [list_to_tuple(decode_cells(Row, [])) | Acc]).
 
 -spec decode_numeric(binary()) -> float().
 decode_numeric(Num) ->

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -54,10 +54,10 @@
 -spec encode_field_type(atom()) -> atom().
 encode_field_type(binary) ->
     'BINARY';
-encode_field_type(sint64) ->
+encode_field_type(integer) ->
     'SINT64';
-encode_field_type(float64) ->
-    'FLOAT64';
+encode_field_type(float) ->
+    'DOUBLE';
 encode_field_type(timestamp) ->
     'TIMESTAMP';
 encode_field_type(boolean) ->
@@ -75,16 +75,17 @@ decode_columns(Columns) ->
 -spec encode_rows(list(list({binary(), ldbvalue()}))) -> [#tsrow{}].
 %% @ignore copied from riakc_ts_put_operator; inverse of make_data
 encode_rows(Measurements) ->
-    lists:map(fun encode_row/1, Measurements).
+    [encode_row(M) || M <- Measurements].
 
 -spec encode_cells(list({binary(), ldbvalue()})) -> [#tscell{}].
 encode_cells(Cells) ->
-    lists:map(fun encode_cell/1, Cells).
+    [encode_cell(C) || C <- Cells].
 
 
 -spec decode_rows([#tsrow{}]) -> list(tuple()).
 decode_rows(Rows) ->
-    decode_rows(Rows, []).
+    [list_to_tuple(decode_cells(Cells)) || #tsrow{cells = Cells} <- Rows].
+
 
 -spec decode_cells([#tscell{}]) -> list(ldbvalue()).
 decode_cells(Cells) ->
@@ -105,8 +106,8 @@ encode_tsgetreq(Bucket, Key, Options) ->
 %% local functions
 
 -spec encode_row(list(ldbvalue())) -> #tsrow{}.
-encode_row(MeasureRow) ->
-    #tsrow{cells = lists:map(fun encode_cell/1, MeasureRow)}.
+encode_row(Cells) ->
+    #tsrow{cells = [encode_cell(C) || C <- Cells]}.
 
 -spec encode_cell(ldbvalue()) -> #tscell{}.
 encode_cell(V) when is_binary(V) ->


### PR DESCRIPTION
There were unnecessary binary-to-float/integer conversions happening in the `riak_pb_ts_codec`, which apparently, indirectly, triggered regressions in ts_* modules after the work to keep floats natively.

Precisely what was broken is hard to say with certainty, in part because for some time into the coding session I was using protobuf-2.6.1 instead of the required 2.5.0. However, the item clearly needing to be fixed was the appearance of values like <<"1.2223334e+22">> in `#tscell.numeric_value`, which was wrong and which is getting fixed by this commit.

ts_basic, which now puts values on both sides of the sint64_max boundary, now passes. 