### PR TITLE
include a list of #tscolumndescription in #tsgetresp

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -349,7 +349,8 @@ message TsGetReq {
 }
 
 message TsGetResp {
-  repeated TsRow rows = 1;  // 0 or 1 rows, that is
+  repeated TsColumnDescription columns = 1;
+  repeated TsRow rows = 2;  // 0 or 1 rows, that is
 }
 
 


### PR DESCRIPTION
RTS-480, needed for https://github.com/basho/riak-erlang-client/pull/242. To be reviewed after https://github.com/basho/riak_pb/pull/145.