### PR TITLE
Ready: Rename float, integer, and binary to double, sint64, and varchar for column type info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,9 @@ python*/
 # Java
 target/*
 
+#IntelliJ
+.idea/
+riak_pb.iml
+
 # C
 c/*

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -52,11 +52,11 @@
 
 
 -spec encode_field_type(atom()) -> atom().
-encode_field_type(binary) ->
+encode_field_type(varchar) ->
     'BINARY';
-encode_field_type(integer) ->
+encode_field_type(sint64) ->
     'SINT64';
-encode_field_type(float) ->
+encode_field_type(double) ->
     'DOUBLE';
 encode_field_type(timestamp) ->
     'TIMESTAMP';


### PR DESCRIPTION
Coincides with these PRs:
https://github.com/basho/riak_ql/pull/36
https://github.com/basho/riak_kv/pull/1247
https://github.com/basho/eleveldb/pull/167
https://github.com/basho/riak_test/pull/915