### PR TITLE
riak_ts.proto: Using different java outer class name value than riak_kv.proto.

### DIFF
--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -27,7 +27,7 @@
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
-option java_outer_classname = "RiakKvPB";
+option java_outer_classname = "RiakTsPB";
 
 import "riak.proto"; // for RpbPair
 


### PR DESCRIPTION
Currently both riak_kv.proto and riak_ts.proto have the same `java_outer_classname` value. When the java PB package is built, the TS proto class overwrites the KV proto class :/

Need to change it to "RiakTsPB".