### PR TITLE
pb messages for TS list_keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ notifications:
 otp_release:
   - R15B01
   - R15B
-  - R14B04
-  - R14B03

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -61,6 +61,8 @@
 95,TsDelResp,riak_ts
 96,TsGetReq,riak_ts
 97,TsGetResp,riak_ts
+98,TsListKeysReq,riak_ts
+99,TsListKeysResp,riak_ts
 253,RpbAuthReq,riak
 254,RpbAuthResp,riak
 255,RpbStartTls,riak

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -37,9 +37,7 @@
          encode_cells/1,
          decode_rows/1,
          decode_cells/1,
-         encode_field_type/1,
-         encode_tsdelreq/3,
-         encode_tsgetreq/3]).
+         encode_field_type/1]).
 
 -type tsrow() :: #tsrow{}.
 -export_type([tsrow/0]).
@@ -91,16 +89,6 @@ decode_rows(Rows) ->
 decode_cells(Cells) ->
     decode_cells(Cells, []).
 
-
-encode_tsdelreq(Bucket, Key, Options) ->
-    #tsdelreq{table   = Bucket,
-              key     = encode_cells(Key),
-              vclock  = proplists:get_value(vclock, Options),
-              timeout = proplists:get_value(timeout, Options)}.
-encode_tsgetreq(Bucket, Key, Options) ->
-    #tsgetreq{table   = Bucket,
-              key     = encode_cells(Key),
-              timeout = proplists:get_value(timeout, Options)}.
 
 %% ---------------------------------------
 %% local functions

--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -109,3 +109,13 @@ message TsCell {
   optional bool boolean_value = 4;
   optional double double_value = 5;
 }
+
+message TsListKeysReq {
+  required bytes table = 1;
+  optional uint32 timeout = 2;
+}
+
+message TsListKeysResp {
+  repeated TsRow keys = 1;
+  optional bool done = 2;
+}


### PR DESCRIPTION
RTS-203.

With incidental removal of a couple of questionable functions `encode_ts{del,get}req/3`.

Required for https://github.com/basho/riak_kv/pull/1268 and https://github.com/basho/riak-erlang-client/pull/249.