### PR TITLE
Revert "drop encode_ts{ddel,get}req"

### DIFF
--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -27,7 +27,8 @@
 
 -include("riak_ts_pb.hrl").
 
--export([encode_rows/2,
+-export([encode_columnnames/1,
+         encode_rows/2,
          encode_rows_non_strict/1,
          decode_rows/1,
          encode_cells/1,
@@ -47,11 +48,18 @@
 %% -type pbvalue() :: binary() | integer() | boolean().
 -export_type([ldbvalue/0]).
 
+%% Column names are binary only.
+-type tscolumnname() :: binary().
 %% Possible column type values supported and returned from the timeseries DDL.
 -type tscolumntype() :: varchar | sint64 | timestamp | boolean | double.
 %% Possible column type values that protocol buffers supports for enumeration purposes.
 -type tscolumntypePB() :: 'VARCHAR' | 'SINT64' | 'TIMESTAMP' | 'BOOLEAN' | 'DOUBLE'.
--export_type([tscolumntype/0, tscolumntypePB/0]).
+-export_type([tscolumnname/0, tscolumntype/0, tscolumntypePB/0]).
+
+%% @doc Convert a list of column names to partial #tscolumndescription records.
+-spec encode_columnnames(list(tscolumnname())) -> list(#tscolumndescription{}).
+encode_columnnames(ColumnNames) ->
+    [#tscolumndescription{name = C} || C <- ColumnNames].
 
 %% @doc Convert time series field type atoms returned from the DDL modules
 %% into Protobuf compatible upper case atoms.

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -29,6 +29,7 @@
 
 -export([encode_rows/2,
          decode_rows/1,
+         encode_cells/1,
          decode_cells/1,
          encode_field_type/1,
          encode_tsdelreq/3,
@@ -81,6 +82,10 @@ encode_rows(ColumnTypes, Rows) ->
 -spec decode_rows([#tsrow{}]) -> list(tuple()).
 decode_rows(Rows) ->
     [list_to_tuple(decode_cells(Cells)) || #tsrow{cells = Cells} <- Rows].
+
+-spec encode_cells(list({binary(), ldbvalue()})) -> [#tscell{}].
+encode_cells(Cells) ->
+    [encode_cell(C) || C <- Cells].
 
 %% @doc Decode a list of timeseries #tscell{} to a list of ldbvalue().
 -spec decode_cells([#tscell{}]) -> list(ldbvalue()).

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -83,7 +83,7 @@ encode_rows(ColumnTypes, Rows) ->
 decode_rows(Rows) ->
     [list_to_tuple(decode_cells(Cells)) || #tsrow{cells = Cells} <- Rows].
 
--spec encode_cells(list({binary(), ldbvalue()})) -> [#tscell{}].
+-spec encode_cells(list({tscolumntype(), ldbvalue()})) -> [#tscell{}].
 encode_cells(Cells) ->
     [encode_cell(C) || C <- Cells].
 

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -30,7 +30,9 @@
 -export([encode_rows/2,
          decode_rows/1,
          decode_cells/1,
-         encode_field_type/1]).
+         encode_field_type/1,
+         encode_tsdelreq/3,
+         encode_tsgetreq/3]).
 
 
 -type tsrow() :: #tsrow{}.
@@ -85,6 +87,16 @@ decode_rows(Rows) ->
 decode_cells(Cells) ->
     decode_cells(Cells, []).
 
+
+encode_tsdelreq(Bucket, Key, Options) ->
+    #tsdelreq{table   = Bucket,
+              key     = encode_cells(Key),
+              vclock  = proplists:get_value(vclock, Options),
+              timeout = proplists:get_value(timeout, Options)}.
+encode_tsgetreq(Bucket, Key, Options) ->
+    #tsgetreq{table   = Bucket,
+              key     = encode_cells(Key),
+              timeout = proplists:get_value(timeout, Options)}.
 
 %% ---------------------------------------
 %% local functions


### PR DESCRIPTION
This reverts commit b92391d4905c90f12eb0de00ae5393422df584d6.

A hotfix to unbreak riak-erlang-client pending https://github.com/basho/riak-erlang-client/pull/249.