### PR TITLE
Future proof the TsQueryReq/Resp messages to permit streaming.

### DIFF
--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -36,11 +36,13 @@ import "riak.proto"; // for RpbPair
 message TsQueryReq {
   // left optional to support parameterized queries in the future
   optional TsInterpolation query = 1;
+  optional bool stream = 2 [default = false];
 }
 
 message TsQueryResp {
   repeated TsColumnDescription columns = 1;
   repeated TsRow rows = 2;  // 0 to n rows
+  optional bool done = 3 [default = true];
 }
 
 


### PR DESCRIPTION
The query mechanism could potentially return large volumes of data, even if using pagination/limits.  At the moment all results are sent back as a single message, which means if you query a gig of data, you have to build it up either in the qry worker or the PB server process on the server before you can send it.

We're very close to shipping 1.0 so I don't want to make radical changes.  However, I think we can make the change below and just recompile the clients to make them future proof (as long as they can handle the default syntax in the proto file).

If we don't change the clients:
   they will send a default message with streaming disabled.

If we don't change the server:
   if clients request streaming, it will be ignored.
   messages will always be sent with done=true as the only message.

Once we change the serve
   It will respect the streaming flag, and only send streaming messages to clients that have been updated to request them.

This should just be a recompile, then we can fix clients/server post-1.0 without having to change message formats.  There should be no additional overhead on the protobuf messages (small though it would be) as defaults are not sent.
