### PR TITLE
riak_pb NIF support for TsPutReq and TsQueryResp messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "riak_kv_ts"]
+	path = riak_kv_ts
+	url = git@github.com:basho/riak_kv_ts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps
+.PHONY: deps pb_nif
 
 all: deps compile_all
 
@@ -151,3 +151,18 @@ c_release: c_compile
 	@mkdir -p $(C_PREFIX)/include
 	@cp -p $(C_DIR)/*.c $(C_PREFIX)
 	@cp -p $(C_DIR)/*.h $(C_PREFIX)/include
+
+nif_build := $(wildcard riak_kv_ts/Makefile)
+
+$(info nif_build wildcard is $(wildcard riak_kv_ts/Makefile) and curdir is $(CURDIR))
+
+ifneq ($(nif_build),)
+B:=$(CURDIR)
+pb_nif : $B/riak_kv_ts/compile
+
+$(info Attempt to load nif_build: $(nif_build))
+include $(nif_build)
+else
+pb_nif:
+
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+REBAR ?= ./rebar
+
 .PHONY: deps pb_nif
 
 all: deps compile_all
@@ -154,13 +156,11 @@ c_release: c_compile
 
 nif_build := $(wildcard riak_kv_ts/Makefile)
 
-$(info nif_build wildcard is $(wildcard riak_kv_ts/Makefile) and curdir is $(CURDIR))
-
 ifneq ($(nif_build),)
 B:=$(CURDIR)
+
 pb_nif : $B/riak_kv_ts/compile
 
-$(info Attempt to load nif_build: $(nif_build))
 include $(nif_build)
 else
 pb_nif:

--- a/rebar.config
+++ b/rebar.config
@@ -15,3 +15,6 @@
 {escript_name, "doesnothavescript"}.
 
 {edoc_opts, [{preprocess, true}]}.
+
+{pre_hooks, [{compile, "make pb_nif"}]}.
+

--- a/rebar.config
+++ b/rebar.config
@@ -18,3 +18,4 @@
 
 {pre_hooks, [{compile, "make pb_nif"}]}.
 
+{post_hooks, [{'get-deps', "git submodule update --init --recursive"}]}.

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -24,16 +24,10 @@
 /*
 ** Revision: 1.4
 */
-syntax = "proto2";
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakPB";
-
-// C++ options
-//  LITE_RUNTIME proved faster in tests, hence used for time series
-option optimize_for = LITE_RUNTIME;
-option cc_enable_arenas = true;
 
 // Error response - may be generated for any Req
 message RpbErrorResp {

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -24,11 +24,16 @@
 /*
 ** Revision: 1.4
 */
+syntax = "proto2";
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakPB";
 
+// C++ options
+//  LITE_RUNTIME proved faster in tests, hence used for time series
+option optimize_for = LITE_RUNTIME;
+option cc_enable_arenas = true;
 
 // Error response - may be generated for any Req
 message RpbErrorResp {

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -29,6 +29,7 @@
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakPB";
 
+
 // Error response - may be generated for any Req
 message RpbErrorResp {
     required bytes errmsg = 1;

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -24,7 +24,6 @@
 /*
 ** Revision: 1.4
 */
-syntax = "proto2";
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -29,6 +29,9 @@
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
 
+// C++ specific option to enable Arenas
+option cc_enable_arenas = true;
+
 import "riak.proto"; // for RpbPair
 
 // Get ClientId Request - no message defined, just send RpbGetClientIdReq message code

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -30,11 +30,6 @@ syntax = "proto2";
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
 
-// C++ options
-//  LITE_RUNTIME proved faster in tests, hence used for time series
-option optimize_for = LITE_RUNTIME;
-option cc_enable_arenas = true;
-
 import "riak.proto"; // for RpbPair
 
 // Get ClientId Request - no message defined, just send RpbGetClientIdReq message code

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -30,9 +30,7 @@ syntax = "proto2";
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
 
-// C++ options
-//  LITE_RUNTIME proved faster in tests, hence used for time series
-option optimize_for = LITE_RUNTIME;
+// C++ specific option to enable Arenas
 option cc_enable_arenas = true;
 
 import "riak.proto"; // for RpbPair

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -30,7 +30,9 @@ syntax = "proto2";
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
 
-// C++ specific option to enable Arenas
+// C++ options
+//  LITE_RUNTIME proved faster in tests, hence used for time series
+option optimize_for = LITE_RUNTIME;
 option cc_enable_arenas = true;
 
 import "riak.proto"; // for RpbPair

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -24,12 +24,15 @@
 /*
 ** Revision: 1.4
 */
+syntax = "proto2";
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
 
-// C++ specific option to enable Arenas
+// C++ options
+//  LITE_RUNTIME proved faster in tests, hence used for time series
+option optimize_for = LITE_RUNTIME;
 option cc_enable_arenas = true;
 
 import "riak.proto"; // for RpbPair

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -24,16 +24,10 @@
 /*
 ** Revision: 1.4
 */
-syntax = "proto2";
 
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";
-
-// C++ options
-//  LITE_RUNTIME proved faster in tests, hence used for time series
-option optimize_for = LITE_RUNTIME;
-option cc_enable_arenas = true;
 
 import "riak.proto"; // for RpbPair
 

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -126,9 +126,7 @@ init() ->
                  Dir ->
                      filename:join(Dir, "riak_pb_codec")
              end,
-    erlang:load_nif(SoName, 0),
-
-    ok.
+    ok = erlang:load_nif(SoName, 0).
 
 encode_tsputreq(Msg) ->
     MsgType = element(1, Msg),
@@ -468,7 +466,8 @@ encode_commit_hook({struct, Props}=Hook) ->
             erlang:error(badarg, [Hook])
     end.
 
--spec decode_commit_hooks([ #rpbcommithook{} ]) ->  [ commit_hook_property() ].
+%% @doc Converts a list of RpbCommitHook messages into commit hooks.
+-spec decode_commit_hooks(#rpbcommithook{} | [ #rpbcommithook{} ]) ->  commit_hook_property() .
 decode_commit_hooks(Hooks) ->
     [ decode_commit_hook(Hook) || Hook <- Hooks,
                                   Hook =/= #rpbcommithook{modfun=undefined, name=undefined} ].

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -87,7 +87,7 @@
 %% to perform optimized decoding.
 -define(TIMESERIES_QUERY_RESP, 91).
 
--spec init() -> any().
+-spec init() -> ok | {error, any()}.
 init() ->
     SoName = case code:priv_dir(?MODULE) of
                  {error, bad_name} ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -100,9 +100,7 @@ init() ->
                  Dir ->
                      filename:join(Dir, "riak_pb_codec")
              end,
-    erlang:load_nif(SoName, 0),
-
-    ok.
+    ok = erlang:load_nif(SoName, 0).
 
 encode_tsputreq(Msg) ->
     MsgType = element(1, Msg),
@@ -444,7 +442,7 @@ encode_commit_hook({struct, Props}=Hook) ->
     end.
 
 %% @doc Converts a list of RpbCommitHook messages into commit hooks.
--spec decode_commit_hooks([ #rpbcommithook{} ]) -> [ commit_hook_property() ].
+-spec decode_commit_hooks(#rpbcommithook{} | [ #rpbcommithook{} ]) ->  commit_hook_property() .
 decode_commit_hooks(Hooks) ->
     [ decode_commit_hook(Hook) || Hook <- Hooks,
                                   Hook =/= #rpbcommithook{modfun=undefined, name=undefined} ].

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -101,7 +101,6 @@ init() ->
     ok.
 
 encode_tsputreq(Msg) ->
-    io:format("bubba printf 1, Msg : ~p", [Msg]),
     MsgType = element(1, Msg),
     Encoder = encoder_for(MsgType),
     [msg_code(MsgType) | Encoder:encode(Msg)].

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -127,7 +127,6 @@ init() ->
     ok.
 
 encode_tsputreq(Msg) ->
-    io:format("bubba printf 1, Msg : ~p", [Msg]),
     MsgType = element(1, Msg),
     Encoder = encoder_for(MsgType),
     [msg_code(MsgType) | Encoder:encode(Msg)].

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -113,7 +113,7 @@ encode_tsputreq(Msg) ->
 %% to perform optimized decoding.
 -define(TIMESERIES_QUERY_RESP, 91).
 
--spec init() -> any().
+-spec init() -> ok | {error, any()}.
 init() ->
     SoName = case code:priv_dir(?MODULE) of
                  {error, bad_name} ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -50,8 +50,7 @@
          encode_modfun/1,
          decode_modfun/2,
          encode_commit_hooks/1,
-         decode_commit_hooks/1,
-         encode_tsputreq/1
+         decode_commit_hooks/1
         ]).
 
 -on_load(init/0).
@@ -171,6 +170,13 @@ decode_tsqueryresp(MsgData) ->
 %% dictionary to indicate whether the encoding should use protobuffs
 %% or straight term_to_binary encoding.
 -spec decode(integer(), binary()) -> atom() | tuple().
+decode(MsgCode, MsgData) ->
+    case get(pb_use_native_encoding) of
+        true ->
+            decode_raw(MsgCode, MsgData);
+        _ ->
+            decode_pb(MsgCode, MsgData)
+    end.
 
 decode_pb(MsgCode, <<>>) ->
     msg_type(MsgCode);

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -108,6 +108,31 @@ encode_tsputreq(Msg) ->
     [msg_code(MsgType) | Encoder:encode(Msg)].
 
 
+
+-spec init() -> any().
+init() ->
+    SoName = case code:priv_dir(?MODULE) of
+                 {error, bad_name} ->
+                     case code:which(?MODULE) of
+                         Filename when is_list(Filename) ->
+                             filename:join([filename:dirname(Filename),"../priv", "riak_pb_codec"]);
+                         _ ->
+                             filename:join("../priv", "riak_pb_codec")
+                     end;
+                 Dir ->
+                     filename:join(Dir, "riak_pb_codec")
+             end,
+    erlang:load_nif(SoName, 0),
+
+    ok.
+
+encode_tsputreq(Msg) ->
+    io:format("bubba printf 1, Msg : ~p", [Msg]),
+    MsgType = element(1, Msg),
+    Encoder = encoder_for(MsgType),
+    [msg_code(MsgType) | Encoder:encode(Msg)].
+
+
 %% @doc Create an iolist of msg code and protocol buffer
 %% message. Replaces `riakc_pb:encode/1'.
 %%

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -112,7 +112,6 @@ encode_tsputreq(Msg) ->
 %% allow our nif interface to identify the message for which we wish
 %% to perform optimized decoding.
 -define(TIMESERIES_QUERY_RESP, 91).
->>>>>>> Add code to pull in supplemental NIF.
 
 -spec init() -> any().
 init() ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -32,7 +32,8 @@
 -compile(export_all).
 -endif.
 
--export([encode/1,      %% riakc_pb:encode
+-export([init/0,
+         encode/1,      %% riakc_pb:encode
          decode/2,      %% riakc_pb:decode
          msg_type/1,    %% riakc_pb:msg_type
          msg_code/1,    %% riakc_pb:msg_code
@@ -49,8 +50,11 @@
          encode_modfun/1,
          decode_modfun/2,
          encode_commit_hooks/1,
-         decode_commit_hooks/1
+         decode_commit_hooks/1,
+         encode_tsputreq/1
         ]).
+
+-on_load(init/0).
 
 %% @type modfun_property().
 %%
@@ -78,6 +82,31 @@
 %% Bucket properties that are commit hooks have this format.
 -type commit_hook_property() :: [ {struct, [{commit_hook_field(), binary()}]} ].
 
+
+-spec init() -> any().
+init() ->
+    SoName = case code:priv_dir(?MODULE) of
+                 {error, bad_name} ->
+                     case code:which(?MODULE) of
+                         Filename when is_list(Filename) ->
+                             filename:join([filename:dirname(Filename),"../priv", "riak_pb_codec"]);
+                         _ ->
+                             filename:join("../priv", "riak_pb_codec")
+                     end;
+                 Dir ->
+                     filename:join(Dir, "riak_pb_codec")
+             end,
+    erlang:load_nif(SoName, 0),
+
+    ok.
+
+encode_tsputreq(Msg) ->
+    io:format("bubba printf 1, Msg : ~p", [Msg]),
+    MsgType = element(1, Msg),
+    Encoder = encoder_for(MsgType),
+    [msg_code(MsgType) | Encoder:encode(Msg)].
+
+
 %% @doc Create an iolist of msg code and protocol buffer
 %% message. Replaces `riakc_pb:encode/1'.
 %%
@@ -96,6 +125,12 @@ encode(Msg) ->
 
 encode_pb(Msg) when is_atom(Msg) ->
     [msg_code(Msg)];
+encode_pb({tsputreq, _, _, _}=Msg) ->
+    encode_tsputreq(Msg);
+
+%%    MsgType = element(1, Msg),
+%%    Encoder = encoder_for(MsgType),
+%%    [msg_code(MsgType) | Encoder:encode(Msg)];
 encode_pb(Msg) when is_tuple(Msg) ->
     MsgType = element(1, Msg),
     Encoder = encoder_for(MsgType),

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -80,7 +80,7 @@
 %% @type commit_hook_property().
 %%
 %% Bucket properties that are commit hooks have this format.
--type commit_hook_property() :: [ {struct, [{commit_hook_field(), binary()}]} ].
+-type commit_hook_property() :: {struct, [{commit_hook_field(), binary()}]}.
 
 %% The protobuf message ID for a timeseries query response, needed to
 %% allow our nif interface to identify the message for which we wish
@@ -422,12 +422,11 @@ decode_modfun(#rpbmodfun{module=Mod, function=Fun}=MF, _Prop) ->
             {binary_to_atom(Mod, latin1), binary_to_atom(Fun, latin1)}
     end.
 
-%% @doc Converts a list of commit hooks into a list of RpbCommitHook
-%% messages.
 -spec encode_commit_hooks([commit_hook_property()]) -> [ #rpbcommithook{} ].
 encode_commit_hooks(Hooks) ->
     [ encode_commit_hook(Hook) || Hook <- Hooks ].
 
+-spec encode_commit_hook(commit_hook_property()) -> #rpbcommithook{}.
 encode_commit_hook({struct, Props}=Hook) ->
     FoundProps = [ lists:keymember(Field, 1, Props) ||
                      Field <- [<<"mod">>, <<"fun">>, <<"name">>]],
@@ -441,12 +440,12 @@ encode_commit_hook({struct, Props}=Hook) ->
             erlang:error(badarg, [Hook])
     end.
 
-%% @doc Converts a list of RpbCommitHook messages into commit hooks.
--spec decode_commit_hooks(#rpbcommithook{} | [ #rpbcommithook{} ]) ->  commit_hook_property() .
+-spec decode_commit_hooks([ #rpbcommithook{} ]) ->  [ commit_hook_property() ].
 decode_commit_hooks(Hooks) ->
     [ decode_commit_hook(Hook) || Hook <- Hooks,
                                   Hook =/= #rpbcommithook{modfun=undefined, name=undefined} ].
 
+-spec decode_commit_hook(#rpbcommithook{}) -> commit_hook_property().
 decode_commit_hook(#rpbcommithook{modfun = Modfun}) when Modfun =/= undefined ->
     decode_modfun(Modfun, commit_hook);
 decode_commit_hook(#rpbcommithook{name = Name}) when Name =/= undefined ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -108,6 +108,10 @@ encode_tsputreq(Msg) ->
     [msg_code(MsgType) | Encoder:encode(Msg)].
 
 
+%% The protobuf message ID for a timeseries query response, needed to
+%% allow our nif interface to identify the message for which we wish
+%% to perform optimized decoding.
+-define(TIMESERIES_QUERY_RESP, 91).
 
 -spec init() -> any().
 init() ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -112,6 +112,7 @@ encode_tsputreq(Msg) ->
 %% allow our nif interface to identify the message for which we wish
 %% to perform optimized decoding.
 -define(TIMESERIES_QUERY_RESP, 91).
+>>>>>>> Add code to pull in supplemental NIF.
 
 -spec init() -> any().
 init() ->


### PR DESCRIPTION
This branch contains Erlang changes to support a C++ implementation of protocol buffers used for objects containing a large number of rows: TsPutReq and TsQueryResp.

A detailed discussion of the changes is here:

   https://github.com/basho/riak_pb/wiki/mv-cpp-pb-timeseries1

This pull request requires basho/riak_kv_ts#1 (RIAK-1433) which is for mv-cpp-pb-timeseries1 branch against riak_kv_ts repository.