### PR TITLE
Support raw Erlang term_to_binary

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -6,6 +6,6 @@ riak_dt_pb.erl
 riak_search_pb.erl
 riak_yokozuna_pb.erl
 ## Insufficient typing on record in generated code
-riak_pb_codec.erl:349: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
+riak_pb_codec.erl:406: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
 riak_pb_dt_codec.erl:181: The pattern {AtomType, _} can never match the type 'false'

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -170,6 +170,7 @@ message RpbRawTermReq {
     required bool use_raw = 1;
 }
 
-// Erlang term encoding response - no message defined, just send
-// RpbRawTermResp
+message RpbRawTermResp {
+    required bool use_raw = 1;
+}
 

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -166,11 +166,11 @@ message RpbAuthReq {
 }
 
 // Erlang term encoding
-message RpbRawTermReq {
-    required bool use_raw = 1;
+message RpbToggleEncodingReq {
+    required bool use_native = 1;
 }
 
-message RpbRawTermResp {
-    required bool use_raw = 1;
+message RpbToggleEncodingResp {
+    required bool use_native = 1;
 }
 

--- a/src/riak.proto
+++ b/src/riak.proto
@@ -164,3 +164,12 @@ message RpbAuthReq {
     required bytes user = 1;
     required bytes password = 2;
 }
+
+// Erlang term encoding
+message RpbRawTermReq {
+    required bool use_raw = 1;
+}
+
+// Erlang term encoding response - no message defined, just send
+// RpbRawTermResp
+

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -80,9 +80,14 @@
 
 %% @doc Create an iolist of msg code and protocol buffer
 %% message. Replaces `riakc_pb:encode/1'.
+%%
+%% NOTE: ugly hack alert. Rather than attempt to thread this
+%% information through the call chain, we are using the process
+%% dictionary to indicate whether the encoding should use protobuffs
+%% or straight term_to_binary encoding.
 -spec encode(atom() | tuple()) -> iolist().
 encode(Msg) ->
-    case get(use_raw) of
+    case get(pb_use_native_encoding) of
         true ->
             encode_raw(Msg);
         _ ->
@@ -119,9 +124,14 @@ de_stringify(Element) ->
 
 %% @doc Decode a protocol buffer message given its type - if no bytes
 %% return the atom for the message code. Replaces `riakc_pb:decode/2'.
+%%
+%% NOTE: ugly hack alert. Rather than attempt to thread this
+%% information through the call chain, we are using the process
+%% dictionary to indicate whether the encoding should use protobuffs
+%% or straight term_to_binary encoding.
 -spec decode(integer(), binary()) -> atom() | tuple().
 decode(MsgCode, MsgData) ->
-    case get(use_raw) of
+    case get(pb_use_native_encoding) of
         true ->
             decode_raw(MsgCode, MsgData);
         _ ->

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -93,6 +93,8 @@ encode_pb(Msg) when is_tuple(Msg) ->
 
 encode_raw(Msg) when is_atom(Msg) ->
     [msg_code(Msg)];
+encode_raw({Msg}) when is_atom(Msg) ->
+    [msg_code(Msg), []];
 encode_raw(Msg) when is_tuple(Msg) ->
     MsgType = element(1, Msg),
     Code = msg_code(MsgType),

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -96,8 +96,19 @@ encode_raw(Msg) when is_atom(Msg) ->
 encode_raw(Msg) when is_tuple(Msg) ->
     MsgType = element(1, Msg),
     Code = msg_code(MsgType),
-    T2B = term_to_binary(Msg),
+    T2B = term_to_binary(de_stringify(Msg)),
     <<Code:8, T2B/binary>>.
+
+de_stringify(Tuple) when is_tuple(Tuple) ->
+    list_to_tuple(de_stringify(tuple_to_list(Tuple)));
+de_stringify(List) when is_list(List), is_integer(hd(List)) ->
+    %% Yes, this could corrupt utf-8 data, but we should never, ever
+    %% have put it in string format to begin with
+    list_to_binary(List);
+de_stringify(List) when is_list(List) ->
+    lists:map(fun de_stringify/1, List);
+de_stringify(Element) ->
+    Element.
 
 %% @doc Decode a protocol buffer message given its type - if no bytes
 %% return the atom for the message code. Replaces `riakc_pb:decode/2'.

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -91,8 +91,13 @@ encode_pb(Msg) when is_tuple(Msg) ->
     Encoder = encoder_for(MsgType),
     [msg_code(MsgType) | Encoder:encode(Msg)].
 
-encode_raw(Msg) ->
-    term_to_binary(Msg).
+encode_raw(Msg) when is_atom(Msg) ->
+    [msg_code(Msg)];
+encode_raw(Msg) when is_tuple(Msg) ->
+    MsgType = element(1, Msg),
+    Code = msg_code(MsgType),
+    T2B = term_to_binary(Msg),
+    <<Code:8, T2B/binary>>.
 
 %% @doc Decode a protocol buffer message given its type - if no bytes
 %% return the atom for the message code. Replaces `riakc_pb:decode/2'.
@@ -111,6 +116,8 @@ decode_pb(MsgCode, MsgData) ->
     Decoder = decoder_for(MsgCode),
     Decoder:decode(msg_type(MsgCode), MsgData).
 
+decode_raw(MsgCode, <<>>) ->
+    msg_type(MsgCode);
 decode_raw(_MsgCode, MsgData) ->
     binary_to_term(MsgData).
 

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -63,8 +63,8 @@
 97,TsGetResp,riak_ts
 98,TsListKeysReq,riak_ts
 99,TsListKeysResp,riak_ts
-110,RpbRawTermReq,riak
-111,RpbRawTermResp,riak
+110,RpbToggleEncodingReq,riak
+111,RpbToggleEncodingResp,riak
 253,RpbAuthReq,riak
 254,RpbAuthResp,riak
 255,RpbStartTls,riak

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -63,6 +63,8 @@
 97,TsGetResp,riak_ts
 98,TsListKeysReq,riak_ts
 99,TsListKeysResp,riak_ts
+110,RpbRawTermReq,riak
+111,RpbRawTermResp,riak
 253,RpbAuthReq,riak
 254,RpbAuthResp,riak
 255,RpbStartTls,riak


### PR DESCRIPTION
This PR enables the use of native Erlang encoding as an alternative to protobuffs.

Unfortunately, the work required to thread the toggle through all code paths would be a fairly dramatic change, so we are doing it the ugly way by using the process dictionary.

Clients can send a request to the server to convert a connection to "native" mode; once the response is received, all further communications will use `term_to_binary` instead of protobuffs, at least until a request to convert back to pb is sent.