### PR TITLE
Perf/ttb newmsg ts1.0 release candidate v2

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -6,6 +6,6 @@ riak_dt_pb.erl
 riak_search_pb.erl
 riak_yokozuna_pb.erl
 ## Insufficient typing on record in generated code
-riak_pb_codec.erl:409: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
+Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
 riak_pb_dt_codec.erl:181: The pattern {AtomType, _} can never match the type 'false'

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -6,6 +6,6 @@ riak_dt_pb.erl
 riak_search_pb.erl
 riak_yokozuna_pb.erl
 ## Insufficient typing on record in generated code
-riak_pb_codec.erl:406: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
+riak_pb_codec.erl:409: Invalid type specification for function riak_pb_codec:decode_commit_hooks/1. The success typing is ([any()]) -> [{atom(),atom() | [any(),...]} | {'modfun',atom(),atom() | [any(),...]}]
 ## Internal calls only pass empty-list, but calls from other libraries pass proplists
 riak_pb_dt_codec.erl:181: The pattern {AtomType, _} can never match the type 'false'

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.basho.riak.protobuf</groupId>
     <artifactId>riak-pb</artifactId>
-    <version>2.1.1.0</version>
+    <version>2.1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Riak Protocol Buffers</name>

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -33,6 +33,7 @@
 -endif.
 
 -export([encode/1,      %% riakc_pb:encode
+	 encode/2,      %% riakc_pb:encode
          decode/2,      %% riakc_pb:decode
          msg_type/1,    %% riakc_pb:msg_type
          msg_code/1,    %% riakc_pb:msg_code

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -86,13 +86,15 @@
 %% dictionary to indicate whether the encoding should use protobuffs
 %% or straight term_to_binary encoding.
 -spec encode(atom() | tuple()) -> iolist().
-encode(Msg) ->
-    case get(pb_use_native_encoding) of
-        true ->
-            encode_raw(Msg);
-        _ ->
-            encode_pb(Msg)
-    end.
+
+encode(Msg) ->    
+    encode(get(pb_use_native_encoding), Msg).
+
+encode(true, Msg) ->
+    encode_raw(Msg);
+
+encode(false, Msg) ->
+    encode_pb(Msg).
 
 encode_pb(Msg) when is_atom(Msg) ->
     [msg_code(Msg)];

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -93,7 +93,7 @@ encode(Msg) ->
 encode(true, Msg) ->
     encode_raw(Msg);
 
-encode(false, Msg) ->
+encode(_, Msg) ->
     encode_pb(Msg).
 
 encode_pb(Msg) when is_atom(Msg) ->

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -63,6 +63,7 @@
 97,TsGetResp,riak_ts
 98,TsListKeysReq,riak_ts
 99,TsListKeysResp,riak_ts
+100,TsTtbPutReq,riak_ts
 110,RpbToggleEncodingReq,riak
 111,RpbToggleEncodingResp,riak
 253,RpbAuthReq,riak

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -67,7 +67,7 @@
 101,TsCoverageResp,riak_ts
 102,TsCoverageEntry,riak_ts
 103,TsRange,riak_ts
-104,TsPutReqTtb,riak_ts
+104,TsTtbPutReq,riak_ts
 110,RpbToggleEncodingReq,riak
 111,RpbToggleEncodingResp,riak
 253,RpbAuthReq,riak

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -63,7 +63,7 @@
 97,TsGetResp,riak_ts
 98,TsListKeysReq,riak_ts
 99,TsListKeysResp,riak_ts
-100,TsTtbPutReq,riak_ts
+100,TsPutReqTtb,riak_ts
 110,RpbToggleEncodingReq,riak
 111,RpbToggleEncodingResp,riak
 253,RpbAuthReq,riak

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -30,6 +30,7 @@
 -export([encode_columnnames/1,
          encode_rows/2,
          encode_rows_non_strict/1,
+         encode_rows_for_ttb/1,
          decode_rows/1,
          encode_cells/1,
          encode_cells_non_strict/1,
@@ -92,6 +93,14 @@ encode_rows(ColumnTypes, Rows) ->
 %% @end
 encode_rows_non_strict(Rows) ->
     [encode_row_non_strict(Row) || Row <- Rows].
+
+encode_rows_for_ttb(Rows) ->
+    [encode_row_for_ttb(Row) || Row <- Rows].
+
+encode_row_for_ttb(Row) when is_list(Row) ->
+    list_to_tuple(Row);
+encode_row_for_ttb(Row) when is_tuple(Row) ->
+    Row.
 
 %% @doc Decode a list of timeseries #tsrow{} to a list of tuples.
 %% Each row is converted through `decode_cells/1`, and the list

--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -67,7 +67,7 @@ message TsPutReq {
   repeated TsRow rows = 3;
 }
 
-message TsPutReqTtb {
+message TsTtbPutReq {
   required bytes table = 1;
 
   // optional: omitting it should use table order

--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -67,6 +67,15 @@ message TsPutReq {
   repeated TsRow rows = 3;
 }
 
+message TsTtbPutReq {
+  required bytes table = 1;
+
+  // optional: omitting it should use table order
+  repeated TsColumnDescription columns = 2;
+
+  repeated TsRow rows = 3;
+}
+
 message TsPutResp {
 
 }

--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -67,7 +67,7 @@ message TsPutReq {
   repeated TsRow rows = 3;
 }
 
-message TsTtbPutReq {
+message TsPutReqTtb {
   required bytes table = 1;
 
   // optional: omitting it should use table order


### PR DESCRIPTION
This is one of three related PRs (https://github.com/basho/riak_kv/pull/1323 is the corresponding PR for riak_kv, https://github.com/basho/riak-erlang-client/pull/259 is the corresponding PR for riakc), to streamline put requests using TTB encoding instead of PB.
As with the current end-to-end/timeseries branch, the TTB encoded messages are still handled by the riak_kv_pb service; even though they are not PB-encoded messages, they reuse the erlang infrastructure around generating erlang messages from the .proto definitions.

Changes include:

1) replaced case switch in encode with pattern-match version of encode (encode/2), which is now exposed for external use.  Function encode/2 is called directly from the corresponding branch of riakc which needs pb_use_native_encoding both for the encode and serialization.  Passing it as an argument avoids having to looking it up twice in two different places, and replacing the case with a pattern match should give better performance

2) encode_rows_for_ttb is called by riakc to 'serialize' the new message internals.  Does nothing but check for lists and convert to tuples if found

3) Because we are piggybacking on the PB infrastructure, a new message has to be defined in .proto file and added to the registry to correspond to the new streamlined message.  Hence the addition of TsPutReqTtb