### PR TITLE
move tscoverage en/decoders from riak_kv over here

### DIFF
--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -250,12 +250,23 @@ decode_cells([#tscell{varchar_value = undefined,
 %% Copied and modified from riak_kv_pb_coverage:convert_list. Would
 %% be nice to collapse them back together, probably with a closure,
 %% but time and effort.
+-type ts_range() :: {FieldName::binary(),
+                     {{StartVal::integer(), StartIncl::boolean()},
+                      {EndVal::integer(), EndIncl::boolean()}}}.
+
+-spec encode_cover_list([{{IP::string(), Port::non_neg_integer()},
+                          Context::binary(),
+                          ts_range(),
+                          SQLText::binary()}]) -> [#tscoverageentry{}].
 encode_cover_list(Entries) ->
     [#tscoverageentry{ip = IP, port = Port,
                       cover_context = Context,
                       range = encode_ts_range({Range, SQLText})}
      || {{IP, Port}, Context, Range, SQLText} <- Entries].
 
+-spec decode_cover_list([#tscoverageentry{}]) ->
+                               [{{IP::string(), Port::non_neg_integer()},
+                                 CoverContext::binary(), ts_range(), Text::binary()}].
 decode_cover_list(Entries) ->
     [begin
          {RangeStruct, Text} = decode_ts_range(Range),
@@ -264,6 +275,7 @@ decode_cover_list(Entries) ->
                              cover_context = CoverContext,
                              range = Range} <- Entries].
 
+-spec encode_ts_range({ts_range(), binary()}) -> #tsrange{}.
 encode_ts_range({{FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}}, Text}) ->
     #tsrange{field_name            = FieldName,
              lower_bound           = StartVal,
@@ -273,6 +285,7 @@ encode_ts_range({{FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}}, Text})
              desc                  = Text
             }.
 
+-spec decode_ts_range(#tsrange{}) -> {ts_range(), binary()}.
 decode_ts_range(#tsrange{field_name            = FieldName,
                          lower_bound           = StartVal,
                          lower_bound_inclusive = StartIncl,

--- a/src/riak_pb_ts_codec.erl
+++ b/src/riak_pb_ts_codec.erl
@@ -35,7 +35,9 @@
          encode_cells/1,
          encode_cells_non_strict/1,
          decode_cells/1,
-         encode_field_type/1]).
+         encode_field_type/1,
+         encode_cover_list/1,
+         decode_cover_list/1]).
 
 
 -type tsrow() :: #tsrow{}.
@@ -242,6 +244,44 @@ decode_cells([#tscell{varchar_value = undefined,
     %% NULL Cell.
     %% TODO: represent null cells by something other than an empty list. emptyTsCell atom maybe?
     decode_cells(T, [[] | Acc]).
+
+
+
+%% Copied and modified from riak_kv_pb_coverage:convert_list. Would
+%% be nice to collapse them back together, probably with a closure,
+%% but time and effort.
+encode_cover_list(Entries) ->
+    [#tscoverageentry{ip = IP, port = Port,
+                      cover_context = Context,
+                      range = encode_ts_range({Range, SQLText})}
+     || {{IP, Port}, Context, Range, SQLText} <- Entries].
+
+decode_cover_list(Entries) ->
+    [begin
+         {RangeStruct, Text} = decode_ts_range(Range),
+         {{IP, Port}, CoverContext, RangeStruct, Text}
+     end || #tscoverageentry{ip = IP, port = Port,
+                             cover_context = CoverContext,
+                             range = Range} <- Entries].
+
+encode_ts_range({{FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}}, Text}) ->
+    #tsrange{field_name            = FieldName,
+             lower_bound           = StartVal,
+             lower_bound_inclusive = StartIncl,
+             upper_bound           = EndVal,
+             upper_bound_inclusive = EndIncl,
+             desc                  = Text
+            }.
+
+decode_ts_range(#tsrange{field_name            = FieldName,
+                         lower_bound           = StartVal,
+                         lower_bound_inclusive = StartIncl,
+                         upper_bound           = EndVal,
+                         upper_bound_inclusive = EndIncl,
+                         desc                  = Text}) ->
+    {{FieldName, {{StartVal, StartIncl}, {EndVal, EndIncl}}}, Text}.
+
+
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
Move the code assembling `#tscoverageresp` from riak_kv here. The callbacks in the common module serving both PB and TTB messages need to only ever return plain Erlang terms. For PB messages, appropriate codecs will be used (from `riak_pb_ts_codec`), while TTB messages are transmitted (as if) without any conversions.

This PR is required for https://github.com/basho/riak_kv/pull/1382 and https://github.com/basho/riak-erlang-client/pull/277 to pass the tests in https://github.com/basho/riak_test/pull/1037.