### PR TITLE
new field allow_qbuf_reuse in TsQueryReq

### DIFF
--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -38,6 +38,7 @@ message TsQueryReq {
   optional TsInterpolation query = 1;
   optional bool stream = 2 [default = false];
   optional bytes cover_context = 3; // chopped up coverage plan per-req
+  optional bool allow_qbuf_reuse = 4 [default = false];
 }
 
 message TsQueryResp {


### PR DESCRIPTION
RTS-733, RTS-870, RTS-1006

Required by https://github.com/basho/riak_kv/pull/1479, and https://github.com/basho/riak-erlang-client/pull/321.

See https://github.com/basho/riak_kv/pull/1479 for details.
