### PR TITLE
remove TsQueryReq.allow_qbuf_reuse

### DIFF
--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -38,7 +38,6 @@ message TsQueryReq {
   optional TsInterpolation query = 1;
   optional bool stream = 2 [default = false];
   optional bytes cover_context = 3; // chopped up coverage plan per-req
-  optional bool allow_qbuf_reuse = 4 [default = false];
 }
 
 message TsQueryResp {


### PR DESCRIPTION
Required by https://github.com/basho/riak-erlang-client/pull/337 and by https://github.com/basho/riak_kv/pull/1549.

In anticipation of .qbuf_id, which is a better solution generally.