### PR TITLE
remove R15B03 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ otp_release:
 - 18.3
 - 17.5
 - R16B03
-- R15B03
 notifications:
   slack:
     secure: UdKhiXftotGmxwNUROU+TzNVlI9rTRSi9aZDc45NxUDkx55ZbtuJOvyYeXKTwsAfwlcWnsSYNrBdnFzXjcrPEZyRsV5qUqBsWF5zR8MI3sBjjLwCZAHlKDhFxecOkmRCi5Xy+JPViQVzn4RKbJ87KTj+mHvopDKkeVOu9A7HGdE=


### PR DESCRIPTION
Travis chokes on [/include/riak_ts_pb.hrl](https://github.com/basho/riak_pb/blob/develop/include/riak_ts_pb.hrl#L111)  when trying to compile using R15. That shit is 5 years old anyway. It's probably safe to presume that very, very few, people are doing their modern Riak development on R15 @alexmoore this should make your PR https://github.com/basho/riak_pb/pull/218 work