### PR TITLE
Add syntax version to .proto files

### DIFF
--- a/src/riak.proto
+++ b/src/riak.proto
@@ -13,6 +13,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakPB";

--- a/src/riak_dt.proto
+++ b/src/riak_dt.proto
@@ -13,6 +13,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakDtPB";

--- a/src/riak_dt_pb.erl
+++ b/src/riak_dt_pb.erl
@@ -4145,6 +4145,7 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_mapfield/3}).
 v_msg_mapfield(#mapfield{name = F1, type = F2}, Path,
 	       _) ->
     v_type_bytes(F1, [name | Path]),
@@ -4153,6 +4154,7 @@ v_msg_mapfield(#mapfield{name = F1, type = F2}, Path,
 v_msg_mapfield(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, mapfield}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_mapentry/3}).
 v_msg_mapentry(#mapentry{field = F1, counter_value = F2,
 			 set_value = F3, register_value = F4, flag_value = F5,
 			 map_value = F6},
@@ -4187,6 +4189,7 @@ v_msg_mapentry(#mapentry{field = F1, counter_value = F2,
 v_msg_mapentry(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, mapentry}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_dtfetchreq/3}).
 v_msg_dtfetchreq(#dtfetchreq{bucket = F1, key = F2,
 			     type = F3, r = F4, pr = F5, basic_quorum = F6,
 			     notfound_ok = F7, timeout = F8, sloppy_quorum = F9,
@@ -4221,6 +4224,7 @@ v_msg_dtfetchreq(#dtfetchreq{bucket = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_dtvalue/3}).
 v_msg_dtvalue(#dtvalue{counter_value = F1,
 		       set_value = F2, map_value = F3, hll_value = F4,
 		       gset_value = F5},
@@ -4258,6 +4262,7 @@ v_msg_dtvalue(#dtvalue{counter_value = F1,
 v_msg_dtvalue(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, dtvalue}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_dtfetchresp/3}).
 v_msg_dtfetchresp(#dtfetchresp{context = F1, type = F2,
 			       value = F3},
 		  Path, TrUserData) ->
@@ -4270,6 +4275,7 @@ v_msg_dtfetchresp(#dtfetchresp{context = F1, type = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_counterop/3}).
 v_msg_counterop(#counterop{increment = F1}, Path, _) ->
     if F1 == undefined -> ok;
        true -> v_type_sint64(F1, [increment | Path])
@@ -4278,6 +4284,7 @@ v_msg_counterop(#counterop{increment = F1}, Path, _) ->
 v_msg_counterop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, counterop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_setop/3}).
 v_msg_setop(#setop{adds = F1, removes = F2}, Path, _) ->
     if is_list(F1) ->
 	   _ = [v_type_bytes(Elem, [adds | Path]) || Elem <- F1],
@@ -4296,6 +4303,7 @@ v_msg_setop(#setop{adds = F1, removes = F2}, Path, _) ->
 v_msg_setop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, setop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_gsetop/3}).
 v_msg_gsetop(#gsetop{adds = F1}, Path, _) ->
     if is_list(F1) ->
 	   _ = [v_type_bytes(Elem, [adds | Path]) || Elem <- F1],
@@ -4307,6 +4315,7 @@ v_msg_gsetop(#gsetop{adds = F1}, Path, _) ->
 v_msg_gsetop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, gsetop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_hllop/3}).
 v_msg_hllop(#hllop{adds = F1}, Path, _) ->
     if is_list(F1) ->
 	   _ = [v_type_bytes(Elem, [adds | Path]) || Elem <- F1],
@@ -4318,6 +4327,7 @@ v_msg_hllop(#hllop{adds = F1}, Path, _) ->
 v_msg_hllop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, hllop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_mapupdate/3}).
 v_msg_mapupdate(#mapupdate{field = F1, counter_op = F2,
 			   set_op = F3, register_op = F4, flag_op = F5,
 			   map_op = F6},
@@ -4343,6 +4353,7 @@ v_msg_mapupdate(#mapupdate{field = F1, counter_op = F2,
 v_msg_mapupdate(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, mapupdate}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_mapop/3}).
 v_msg_mapop(#mapop{removes = F1, updates = F2}, Path,
 	    TrUserData) ->
     if is_list(F1) ->
@@ -4365,6 +4376,7 @@ v_msg_mapop(#mapop{removes = F1, updates = F2}, Path,
 v_msg_mapop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, mapop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_dtop/3}).
 v_msg_dtop(#dtop{counter_op = F1, set_op = F2,
 		 map_op = F3, hll_op = F4, gset_op = F5},
 	   Path, TrUserData) ->
@@ -4388,6 +4400,7 @@ v_msg_dtop(#dtop{counter_op = F1, set_op = F2,
 v_msg_dtop(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, dtop}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_dtupdatereq/3}).
 v_msg_dtupdatereq(#dtupdatereq{bucket = F1, key = F2,
 			       type = F3, context = F4, op = F5, w = F6,
 			       dw = F7, pw = F8, return_body = F9,
@@ -4429,6 +4442,7 @@ v_msg_dtupdatereq(#dtupdatereq{bucket = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_dtupdateresp/3}).
 v_msg_dtupdateresp(#dtupdateresp{key = F1, context = F2,
 				 counter_value = F3, set_value = F4,
 				 map_value = F5, hll_value = F6,
@@ -4471,6 +4485,7 @@ v_msg_dtupdateresp(#dtupdateresp{key = F1, context = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,'v_enum_MapField.MapFieldType'/2}).
 'v_enum_MapField.MapFieldType'('COUNTER', _Path) -> ok;
 'v_enum_MapField.MapFieldType'('SET', _Path) -> ok;
 'v_enum_MapField.MapFieldType'('REGISTER', _Path) -> ok;
@@ -4483,6 +4498,7 @@ v_msg_dtupdateresp(#dtupdateresp{key = F1, context = F2,
     mk_type_error({invalid_enum, 'MapField.MapFieldType'},
 		  X, Path).
 
+-dialyzer({nowarn_function,'v_enum_DtFetchResp.DataType'/2}).
 'v_enum_DtFetchResp.DataType'('COUNTER', _Path) -> ok;
 'v_enum_DtFetchResp.DataType'('SET', _Path) -> ok;
 'v_enum_DtFetchResp.DataType'('MAP', _Path) -> ok;
@@ -4495,6 +4511,7 @@ v_msg_dtupdateresp(#dtupdateresp{key = F1, context = F2,
     mk_type_error({invalid_enum, 'DtFetchResp.DataType'}, X,
 		  Path).
 
+-dialyzer({nowarn_function,'v_enum_MapUpdate.FlagOp'/2}).
 'v_enum_MapUpdate.FlagOp'('ENABLE', _Path) -> ok;
 'v_enum_MapUpdate.FlagOp'('DISABLE', _Path) -> ok;
 'v_enum_MapUpdate.FlagOp'(V, Path) when is_integer(V) ->
@@ -4503,6 +4520,7 @@ v_msg_dtupdateresp(#dtupdateresp{key = F1, context = F2,
     mk_type_error({invalid_enum, 'MapUpdate.FlagOp'}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -4513,6 +4531,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_sint64/2}).
 v_type_sint64(N, _Path)
     when -9223372036854775808 =< N,
 	 N =< 9223372036854775807 ->
@@ -4524,6 +4543,7 @@ v_type_sint64(X, Path) ->
     mk_type_error({bad_integer, sint64, signed, 64}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -4534,6 +4554,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint64/2}).
 v_type_uint64(N, _Path)
     when 0 =< N, N =< 18446744073709551615 ->
     ok;
@@ -4545,6 +4566,7 @@ v_type_uint64(X, Path) ->
     mk_type_error({bad_integer, uint64, unsigned, 64}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -4552,6 +4574,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -13,6 +13,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakKvPB";

--- a/src/riak_kv_pb.erl
+++ b/src/riak_kv_pb.erl
@@ -13506,6 +13506,7 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_rpblink/3}).
 v_msg_rpblink(#rpblink{bucket = F1, key = F2, tag = F3},
 	      Path, _) ->
     if F1 == undefined -> ok;
@@ -13521,6 +13522,7 @@ v_msg_rpblink(#rpblink{bucket = F1, key = F2, tag = F3},
 v_msg_rpblink(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpblink}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbpair/3}).
 v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 	      _) ->
     v_type_bytes(F1, [key | Path]),
@@ -13531,6 +13533,7 @@ v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 v_msg_rpbpair(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbpair}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbcontent/3}).
 v_msg_rpbcontent(#rpbcontent{value = F1,
 			     content_type = F2, charset = F3,
 			     content_encoding = F4, vtag = F5, links = F6,
@@ -13590,6 +13593,7 @@ v_msg_rpbcontent(#rpbcontent{value = F1,
 v_msg_rpbcontent(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcontent}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbgetresp/3}).
 v_msg_rpbgetresp(#rpbgetresp{content = F1, vclock = F2,
 			     unchanged = F3},
 		 Path, TrUserData) ->
@@ -13612,6 +13616,7 @@ v_msg_rpbgetresp(#rpbgetresp{content = F1, vclock = F2,
 v_msg_rpbgetresp(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbgetresp}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbindexobject/3}).
 v_msg_rpbindexobject(#rpbindexobject{key = F1,
 				     object = F2},
 		     Path, TrUserData) ->
@@ -13621,6 +13626,7 @@ v_msg_rpbindexobject(#rpbindexobject{key = F1,
 v_msg_rpbindexobject(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbindexobject}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbmodfun/3}).
 v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 		Path, _) ->
     v_type_bytes(F1, [module | Path]),
@@ -13629,6 +13635,7 @@ v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 v_msg_rpbmodfun(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbmodfun}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbcommithook/3}).
 v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 				   name = F2},
 		    Path, TrUserData) ->
@@ -13642,6 +13649,7 @@ v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 v_msg_rpbcommithook(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcommithook}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbbucketprops/3}).
 v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 				     allow_mult = F2, last_write_wins = F3,
 				     precommit = F4, has_precommit = F5,
@@ -13766,6 +13774,7 @@ v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 v_msg_rpbbucketprops(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbbucketprops}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbresetbucketreq/3}).
 v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
 					   type = F2},
 			Path, _) ->
@@ -13775,6 +13784,7 @@ v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcsbucketreq/3}).
 v_msg_rpbcsbucketreq(#rpbcsbucketreq{bucket = F1,
 				     start_key = F2, end_key = F3,
 				     start_incl = F4, end_incl = F5,
@@ -13810,11 +13820,13 @@ v_msg_rpbcsbucketreq(#rpbcsbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetclientidreq/3}).
 v_msg_rpbsetclientidreq(#rpbsetclientidreq{client_id =
 					       F1},
 			Path, _) ->
     v_type_bytes(F1, [client_id | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcounterupdatereq/3}).
 v_msg_rpbcounterupdatereq(#rpbcounterupdatereq{bucket =
 						   F1,
 					       key = F2, amount = F3, w = F4,
@@ -13838,6 +13850,7 @@ v_msg_rpbcounterupdatereq(#rpbcounterupdatereq{bucket =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpblistbucketsreq/3}).
 v_msg_rpblistbucketsreq(#rpblistbucketsreq{timeout = F1,
 					   stream = F2, type = F3},
 			Path, _) ->
@@ -13852,6 +13865,7 @@ v_msg_rpblistbucketsreq(#rpblistbucketsreq{timeout = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbbucketkeypreflistitem/3}).
 v_msg_rpbbucketkeypreflistitem(#rpbbucketkeypreflistitem{partition
 							     = F1,
 							 node = F2,
@@ -13865,6 +13879,7 @@ v_msg_rpbbucketkeypreflistitem(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbbucketkeypreflistitem},
 		  X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketkeypreflistresp/3}).
 v_msg_rpbgetbucketkeypreflistresp(#rpbgetbucketkeypreflistresp{preflist
 								   = F1},
 				  Path, TrUserData) ->
@@ -13880,6 +13895,7 @@ v_msg_rpbgetbucketkeypreflistresp(#rpbgetbucketkeypreflistresp{preflist
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpblistbucketsresp/3}).
 v_msg_rpblistbucketsresp(#rpblistbucketsresp{buckets =
 						 F1,
 					     done = F2},
@@ -13896,6 +13912,7 @@ v_msg_rpblistbucketsresp(#rpblistbucketsresp{buckets =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbputresp/3}).
 v_msg_rpbputresp(#rpbputresp{content = F1, vclock = F2,
 			     key = F3},
 		 Path, TrUserData) ->
@@ -13916,11 +13933,13 @@ v_msg_rpbputresp(#rpbputresp{content = F1, vclock = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetclientidresp/3}).
 v_msg_rpbgetclientidresp(#rpbgetclientidresp{client_id =
 						 F1},
 			 Path, _) ->
     v_type_bytes(F1, [client_id | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcoverageentry/3}).
 v_msg_rpbcoverageentry(#rpbcoverageentry{ip = F1,
 					 port = F2, keyspace_desc = F3,
 					 cover_context = F4},
@@ -13936,6 +13955,7 @@ v_msg_rpbcoverageentry(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcoverageentry}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_msg_rpbsetbuckettypereq/3}).
 v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
 						   F1,
 					       props = F2},
@@ -13944,11 +13964,13 @@ v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
     v_msg_rpbbucketprops(F2, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbuckettypereq/3}).
 v_msg_rpbgetbuckettypereq(#rpbgetbuckettypereq{type =
 						   F1},
 			  Path, _) ->
     v_type_bytes(F1, [type | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbdelreq/3}).
 v_msg_rpbdelreq(#rpbdelreq{bucket = F1, key = F2,
 			   rw = F3, vclock = F4, r = F5, w = F6, pr = F7,
 			   pw = F8, dw = F9, timeout = F10, sloppy_quorum = F11,
@@ -13991,6 +14013,7 @@ v_msg_rpbdelreq(#rpbdelreq{bucket = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbputreq/3}).
 v_msg_rpbputreq(#rpbputreq{bucket = F1, key = F2,
 			   vclock = F3, content = F4, w = F5, dw = F6,
 			   return_body = F7, pw = F8, if_not_modified = F9,
@@ -14044,6 +14067,7 @@ v_msg_rpbputreq(#rpbputreq{bucket = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetreq/3}).
 v_msg_rpbgetreq(#rpbgetreq{bucket = F1, key = F2,
 			   r = F3, pr = F4, basic_quorum = F5, notfound_ok = F6,
 			   if_modified = F7, head = F8, deletedvclock = F9,
@@ -14087,6 +14111,7 @@ v_msg_rpbgetreq(#rpbgetreq{bucket = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketkeypreflistreq/3}).
 v_msg_rpbgetbucketkeypreflistreq(#rpbgetbucketkeypreflistreq{bucket
 								 = F1,
 							     key = F2,
@@ -14099,6 +14124,7 @@ v_msg_rpbgetbucketkeypreflistreq(#rpbgetbucketkeypreflistreq{bucket
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbindexresp/3}).
 v_msg_rpbindexresp(#rpbindexresp{keys = F1,
 				 results = F2, continuation = F3, done = F4},
 		   Path, TrUserData) ->
@@ -14124,6 +14150,7 @@ v_msg_rpbindexresp(#rpbindexresp{keys = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetserverinforesp/3}).
 v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
 						     F1,
 						 server_version = F2},
@@ -14136,6 +14163,7 @@ v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcsbucketresp/3}).
 v_msg_rpbcsbucketresp(#rpbcsbucketresp{objects = F1,
 				       continuation = F2, done = F3},
 		      Path, TrUserData) ->
@@ -14156,6 +14184,7 @@ v_msg_rpbcsbucketresp(#rpbcsbucketresp{objects = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbmapredresp/3}).
 v_msg_rpbmapredresp(#rpbmapredresp{phase = F1,
 				   response = F2, done = F3},
 		    Path, _) ->
@@ -14170,6 +14199,7 @@ v_msg_rpbmapredresp(#rpbmapredresp{phase = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcoveragereq/3}).
 v_msg_rpbcoveragereq(#rpbcoveragereq{type = F1,
 				     bucket = F2, min_partitions = F3,
 				     replace_cover = F4,
@@ -14194,6 +14224,7 @@ v_msg_rpbcoveragereq(#rpbcoveragereq{type = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbucketreq/3}).
 v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
 				       props = F2, type = F3},
 		      Path, TrUserData) ->
@@ -14204,6 +14235,7 @@ v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketreq/3}).
 v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
 				       type = F2},
 		      Path, _) ->
@@ -14213,6 +14245,7 @@ v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpblistkeysresp/3}).
 v_msg_rpblistkeysresp(#rpblistkeysresp{keys = F1,
 				       done = F2},
 		      Path, _) ->
@@ -14227,6 +14260,7 @@ v_msg_rpblistkeysresp(#rpblistkeysresp{keys = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbindexreq/3}).
 v_msg_rpbindexreq(#rpbindexreq{bucket = F1, index = F2,
 			       qtype = F3, key = F4, range_min = F5,
 			       range_max = F6, return_terms = F7, stream = F8,
@@ -14279,6 +14313,7 @@ v_msg_rpbindexreq(#rpbindexreq{bucket = F1, index = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcountergetreq/3}).
 v_msg_rpbcountergetreq(#rpbcountergetreq{bucket = F1,
 					 key = F2, r = F3, pr = F4,
 					 basic_quorum = F5, notfound_ok = F6},
@@ -14299,6 +14334,7 @@ v_msg_rpbcountergetreq(#rpbcountergetreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpblistkeysreq/3}).
 v_msg_rpblistkeysreq(#rpblistkeysreq{bucket = F1,
 				     timeout = F2, type = F3},
 		     Path, _) ->
@@ -14311,12 +14347,14 @@ v_msg_rpblistkeysreq(#rpblistkeysreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbauthreq/3}).
 v_msg_rpbauthreq(#rpbauthreq{user = F1, password = F2},
 		 Path, _) ->
     v_type_bytes(F1, [user | Path]),
     v_type_bytes(F2, [password | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbmapredreq/3}).
 v_msg_rpbmapredreq(#rpbmapredreq{request = F1,
 				 content_type = F2},
 		   Path, _) ->
@@ -14324,6 +14362,7 @@ v_msg_rpbmapredreq(#rpbmapredreq{request = F1,
     v_type_bytes(F2, [content_type | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcounterupdateresp/3}).
 v_msg_rpbcounterupdateresp(#rpbcounterupdateresp{value =
 						     F1},
 			   Path, _) ->
@@ -14332,11 +14371,13 @@ v_msg_rpbcounterupdateresp(#rpbcounterupdateresp{value =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketresp/3}).
 v_msg_rpbgetbucketresp(#rpbgetbucketresp{props = F1},
 		       Path, TrUserData) ->
     v_msg_rpbbucketprops(F1, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcountergetresp/3}).
 v_msg_rpbcountergetresp(#rpbcountergetresp{value = F1},
 			Path, _) ->
     if F1 == undefined -> ok;
@@ -14344,6 +14385,7 @@ v_msg_rpbcountergetresp(#rpbcountergetresp{value = F1},
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbindexbodyresp/3}).
 v_msg_rpbindexbodyresp(#rpbindexbodyresp{objects = F1,
 					 continuation = F2, done = F3},
 		       Path, TrUserData) ->
@@ -14364,6 +14406,7 @@ v_msg_rpbindexbodyresp(#rpbindexbodyresp{objects = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbcoverageresp/3}).
 v_msg_rpbcoverageresp(#rpbcoverageresp{entries = F1},
 		      Path, TrUserData) ->
     if is_list(F1) ->
@@ -14378,6 +14421,7 @@ v_msg_rpbcoverageresp(#rpbcoverageresp{entries = F1},
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpberrorresp/3}).
 v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 				 errcode = F2},
 		   Path, _) ->
@@ -14385,6 +14429,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
     v_type_uint32(F2, [errcode | Path]),
     ok.
 
+-dialyzer({nowarn_function,'v_enum_RpbIndexReq.IndexQueryType'/2}).
 'v_enum_RpbIndexReq.IndexQueryType'(eq, _Path) -> ok;
 'v_enum_RpbIndexReq.IndexQueryType'(range, _Path) -> ok;
 'v_enum_RpbIndexReq.IndexQueryType'(V, Path)
@@ -14395,6 +14440,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 		   'RpbIndexReq.IndexQueryType'},
 		  X, Path).
 
+-dialyzer({nowarn_function,'v_enum_RpbBucketProps.RpbReplMode'/2}).
 'v_enum_RpbBucketProps.RpbReplMode'('FALSE', _Path) ->
     ok;
 'v_enum_RpbBucketProps.RpbReplMode'('REALTIME',
@@ -14413,6 +14459,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 		   'RpbBucketProps.RpbReplMode'},
 		  X, Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -14423,6 +14470,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_sint64/2}).
 v_type_sint64(N, _Path)
     when -9223372036854775808 =< N,
 	 N =< 9223372036854775807 ->
@@ -14434,6 +14482,7 @@ v_type_sint64(X, Path) ->
     mk_type_error({bad_integer, sint64, signed, 64}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_int64/2}).
 v_type_int64(N, _Path)
     when -9223372036854775808 =< N,
 	 N =< 9223372036854775807 ->
@@ -14445,6 +14494,7 @@ v_type_int64(X, Path) ->
     mk_type_error({bad_integer, int64, signed, 64}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -14455,6 +14505,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -14462,6 +14513,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->

--- a/src/riak_pb.erl
+++ b/src/riak_pb.erl
@@ -4130,6 +4130,7 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_rpbmodfun/3}).
 v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 		Path, _) ->
     v_type_bytes(F1, [module | Path]),
@@ -4138,6 +4139,7 @@ v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 v_msg_rpbmodfun(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbmodfun}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbcommithook/3}).
 v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 				   name = F2},
 		    Path, TrUserData) ->
@@ -4151,6 +4153,7 @@ v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 v_msg_rpbcommithook(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcommithook}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbbucketprops/3}).
 v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 				     allow_mult = F2, last_write_wins = F3,
 				     precommit = F4, has_precommit = F5,
@@ -4275,6 +4278,7 @@ v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 v_msg_rpbbucketprops(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbbucketprops}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbpair/3}).
 v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 	      _) ->
     v_type_bytes(F1, [key | Path]),
@@ -4283,6 +4287,7 @@ v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbresetbucketreq/3}).
 v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
 					   type = F2},
 			Path, _) ->
@@ -4292,6 +4297,7 @@ v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbuckettypereq/3}).
 v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
 						   F1,
 					       props = F2},
@@ -4300,11 +4306,13 @@ v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
     v_msg_rpbbucketprops(F2, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbuckettypereq/3}).
 v_msg_rpbgetbuckettypereq(#rpbgetbuckettypereq{type =
 						   F1},
 			  Path, _) ->
     v_type_bytes(F1, [type | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetserverinforesp/3}).
 v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
 						     F1,
 						 server_version = F2},
@@ -4317,6 +4325,7 @@ v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbucketreq/3}).
 v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
 				       props = F2, type = F3},
 		      Path, TrUserData) ->
@@ -4327,6 +4336,7 @@ v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketreq/3}).
 v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
 				       type = F2},
 		      Path, _) ->
@@ -4336,17 +4346,20 @@ v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbauthreq/3}).
 v_msg_rpbauthreq(#rpbauthreq{user = F1, password = F2},
 		 Path, _) ->
     v_type_bytes(F1, [user | Path]),
     v_type_bytes(F2, [password | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketresp/3}).
 v_msg_rpbgetbucketresp(#rpbgetbucketresp{props = F1},
 		       Path, TrUserData) ->
     v_msg_rpbbucketprops(F1, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpberrorresp/3}).
 v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 				 errcode = F2},
 		   Path, _) ->
@@ -4354,6 +4367,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
     v_type_uint32(F2, [errcode | Path]),
     ok.
 
+-dialyzer({nowarn_function,'v_enum_RpbBucketProps.RpbReplMode'/2}).
 'v_enum_RpbBucketProps.RpbReplMode'('FALSE', _Path) ->
     ok;
 'v_enum_RpbBucketProps.RpbReplMode'('REALTIME',
@@ -4372,6 +4386,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 		   'RpbBucketProps.RpbReplMode'},
 		  X, Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -4382,6 +4397,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -4392,6 +4408,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -4399,6 +4416,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->

--- a/src/riak_search.proto
+++ b/src/riak_search.proto
@@ -13,6 +13,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 import "riak.proto";
 
 // java package specifiers

--- a/src/riak_search_pb.erl
+++ b/src/riak_search_pb.erl
@@ -5080,6 +5080,7 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_rpbmodfun/3}).
 v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 		Path, _) ->
     v_type_bytes(F1, [module | Path]),
@@ -5088,6 +5089,7 @@ v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 v_msg_rpbmodfun(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbmodfun}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbcommithook/3}).
 v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 				   name = F2},
 		    Path, TrUserData) ->
@@ -5101,6 +5103,7 @@ v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 v_msg_rpbcommithook(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcommithook}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbbucketprops/3}).
 v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 				     allow_mult = F2, last_write_wins = F3,
 				     precommit = F4, has_precommit = F5,
@@ -5225,6 +5228,7 @@ v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 v_msg_rpbbucketprops(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbbucketprops}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbpair/3}).
 v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 	      _) ->
     v_type_bytes(F1, [key | Path]),
@@ -5235,6 +5239,7 @@ v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 v_msg_rpbpair(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbpair}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbresetbucketreq/3}).
 v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
 					   type = F2},
 			Path, _) ->
@@ -5244,6 +5249,7 @@ v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsearchdoc/3}).
 v_msg_rpbsearchdoc(#rpbsearchdoc{fields = F1}, Path,
 		   TrUserData) ->
     if is_list(F1) ->
@@ -5258,6 +5264,7 @@ v_msg_rpbsearchdoc(#rpbsearchdoc{fields = F1}, Path,
 v_msg_rpbsearchdoc(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbsearchdoc}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbsetbuckettypereq/3}).
 v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
 						   F1,
 					       props = F2},
@@ -5266,11 +5273,13 @@ v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
     v_msg_rpbbucketprops(F2, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbuckettypereq/3}).
 v_msg_rpbgetbuckettypereq(#rpbgetbuckettypereq{type =
 						   F1},
 			  Path, _) ->
     v_type_bytes(F1, [type | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetserverinforesp/3}).
 v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
 						     F1,
 						 server_version = F2},
@@ -5283,6 +5292,7 @@ v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsearchqueryresp/3}).
 v_msg_rpbsearchqueryresp(#rpbsearchqueryresp{docs = F1,
 					     max_score = F2, num_found = F3},
 			 Path, TrUserData) ->
@@ -5302,6 +5312,7 @@ v_msg_rpbsearchqueryresp(#rpbsearchqueryresp{docs = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsearchqueryreq/3}).
 v_msg_rpbsearchqueryreq(#rpbsearchqueryreq{q = F1,
 					   index = F2, rows = F3, start = F4,
 					   sort = F5, filter = F6, df = F7,
@@ -5337,6 +5348,7 @@ v_msg_rpbsearchqueryreq(#rpbsearchqueryreq{q = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbucketreq/3}).
 v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
 				       props = F2, type = F3},
 		      Path, TrUserData) ->
@@ -5347,6 +5359,7 @@ v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketreq/3}).
 v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
 				       type = F2},
 		      Path, _) ->
@@ -5356,17 +5369,20 @@ v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbauthreq/3}).
 v_msg_rpbauthreq(#rpbauthreq{user = F1, password = F2},
 		 Path, _) ->
     v_type_bytes(F1, [user | Path]),
     v_type_bytes(F2, [password | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketresp/3}).
 v_msg_rpbgetbucketresp(#rpbgetbucketresp{props = F1},
 		       Path, TrUserData) ->
     v_msg_rpbbucketprops(F1, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpberrorresp/3}).
 v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 				 errcode = F2},
 		   Path, _) ->
@@ -5374,6 +5390,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
     v_type_uint32(F2, [errcode | Path]),
     ok.
 
+-dialyzer({nowarn_function,'v_enum_RpbBucketProps.RpbReplMode'/2}).
 'v_enum_RpbBucketProps.RpbReplMode'('FALSE', _Path) ->
     ok;
 'v_enum_RpbBucketProps.RpbReplMode'('REALTIME',
@@ -5392,6 +5409,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 		   'RpbBucketProps.RpbReplMode'},
 		  X, Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -5402,6 +5420,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -5412,6 +5431,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -5419,6 +5439,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_float/2}).
 v_type_float(N, _Path) when is_float(N) -> ok;
 v_type_float(N, _Path) when is_integer(N) -> ok;
 v_type_float(infinity, _Path) -> ok;
@@ -5427,6 +5448,7 @@ v_type_float(nan, _Path) -> ok;
 v_type_float(X, Path) ->
     mk_type_error(bad_float_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->

--- a/src/riak_ts.proto
+++ b/src/riak_ts.proto
@@ -14,6 +14,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 // Java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakTsPB";

--- a/src/riak_ts_pb.erl
+++ b/src/riak_ts_pb.erl
@@ -7715,6 +7715,7 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_tsrange/3}).
 v_msg_tsrange(#tsrange{field_name = F1,
 		       lower_bound = F2, lower_bound_inclusive = F3,
 		       upper_bound = F4, upper_bound_inclusive = F5,
@@ -7730,6 +7731,7 @@ v_msg_tsrange(#tsrange{field_name = F1,
 v_msg_tsrange(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tsrange}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_tscoverageentry/3}).
 v_msg_tscoverageentry(#tscoverageentry{ip = F1,
 				       port = F2, cover_context = F3,
 				       range = F4},
@@ -7744,6 +7746,7 @@ v_msg_tscoverageentry(#tscoverageentry{ip = F1,
 v_msg_tscoverageentry(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tscoverageentry}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbmodfun/3}).
 v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 		Path, _) ->
     v_type_bytes(F1, [module | Path]),
@@ -7752,6 +7755,7 @@ v_msg_rpbmodfun(#rpbmodfun{module = F1, function = F2},
 v_msg_rpbmodfun(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbmodfun}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbcommithook/3}).
 v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 				   name = F2},
 		    Path, TrUserData) ->
@@ -7765,6 +7769,7 @@ v_msg_rpbcommithook(#rpbcommithook{modfun = F1,
 v_msg_rpbcommithook(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbcommithook}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbbucketprops/3}).
 v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 				     allow_mult = F2, last_write_wins = F3,
 				     precommit = F4, has_precommit = F5,
@@ -7889,6 +7894,7 @@ v_msg_rpbbucketprops(#rpbbucketprops{n_val = F1,
 v_msg_rpbbucketprops(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbbucketprops}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbpair/3}).
 v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 	      _) ->
     v_type_bytes(F1, [key | Path]),
@@ -7899,6 +7905,7 @@ v_msg_rpbpair(#rpbpair{key = F1, value = F2}, Path,
 v_msg_rpbpair(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbpair}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_rpbresetbucketreq/3}).
 v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
 					   type = F2},
 			Path, _) ->
@@ -7908,6 +7915,7 @@ v_msg_rpbresetbucketreq(#rpbresetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsinterpolation/3}).
 v_msg_tsinterpolation(#tsinterpolation{base = F1,
 				       interpolations = F2},
 		      Path, TrUserData) ->
@@ -7925,6 +7933,7 @@ v_msg_tsinterpolation(#tsinterpolation{base = F1,
 v_msg_tsinterpolation(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tsinterpolation}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_tscoveragereq/3}).
 v_msg_tscoveragereq(#tscoveragereq{query = F1,
 				   table = F2, replace_cover = F3,
 				   unavailable_cover = F4},
@@ -7946,6 +7955,7 @@ v_msg_tscoveragereq(#tscoveragereq{query = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tscell/3}).
 v_msg_tscell(#tscell{varchar_value = F1,
 		     sint64_value = F2, timestamp_value = F3,
 		     boolean_value = F4, double_value = F5},
@@ -7969,6 +7979,7 @@ v_msg_tscell(#tscell{varchar_value = F1,
 v_msg_tscell(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tscell}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_tsdelreq/3}).
 v_msg_tsdelreq(#tsdelreq{table = F1, key = F2,
 			 vclock = F3, timeout = F4},
 	       Path, TrUserData) ->
@@ -7989,6 +8000,7 @@ v_msg_tsdelreq(#tsdelreq{table = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsrow/3}).
 v_msg_tsrow(#tsrow{cells = F1}, Path, TrUserData) ->
     if is_list(F1) ->
 	   _ = [v_msg_tscell(Elem, [cells | Path], TrUserData)
@@ -8002,6 +8014,7 @@ v_msg_tsrow(#tsrow{cells = F1}, Path, TrUserData) ->
 v_msg_tsrow(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tsrow}, X, Path).
 
+-dialyzer({nowarn_function,v_msg_tscolumndescription/3}).
 v_msg_tscolumndescription(#tscolumndescription{name =
 						   F1,
 					       type = F2},
@@ -8013,6 +8026,7 @@ v_msg_tscolumndescription(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, tscolumndescription}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_msg_tsputreq/3}).
 v_msg_tsputreq(#tsputreq{table = F1, columns = F2,
 			 rows = F3},
 	       Path, TrUserData) ->
@@ -8036,6 +8050,7 @@ v_msg_tsputreq(#tsputreq{table = F1, columns = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsgetreq/3}).
 v_msg_tsgetreq(#tsgetreq{table = F1, key = F2,
 			 timeout = F3},
 	       Path, TrUserData) ->
@@ -8053,8 +8068,10 @@ v_msg_tsgetreq(#tsgetreq{table = F1, key = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsdelresp/3}).
 v_msg_tsdelresp(#tsdelresp{}, _Path, _) -> ok.
 
+-dialyzer({nowarn_function,v_msg_tsgetresp/3}).
 v_msg_tsgetresp(#tsgetresp{columns = F1, rows = F2},
 		Path, TrUserData) ->
     if is_list(F1) ->
@@ -8076,6 +8093,7 @@ v_msg_tsgetresp(#tsgetresp{columns = F1, rows = F2},
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbuckettypereq/3}).
 v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
 						   F1,
 					       props = F2},
@@ -8084,11 +8102,13 @@ v_msg_rpbsetbuckettypereq(#rpbsetbuckettypereq{type =
     v_msg_rpbbucketprops(F2, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbuckettypereq/3}).
 v_msg_rpbgetbuckettypereq(#rpbgetbuckettypereq{type =
 						   F1},
 			  Path, _) ->
     v_type_bytes(F1, [type | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_tslistkeysreq/3}).
 v_msg_tslistkeysreq(#tslistkeysreq{table = F1,
 				   timeout = F2},
 		    Path, _) ->
@@ -8098,6 +8118,7 @@ v_msg_tslistkeysreq(#tslistkeysreq{table = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetserverinforesp/3}).
 v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
 						     F1,
 						 server_version = F2},
@@ -8110,6 +8131,7 @@ v_msg_rpbgetserverinforesp(#rpbgetserverinforesp{node =
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbsetbucketreq/3}).
 v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
 				       props = F2, type = F3},
 		      Path, TrUserData) ->
@@ -8120,6 +8142,7 @@ v_msg_rpbsetbucketreq(#rpbsetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketreq/3}).
 v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
 				       type = F2},
 		      Path, _) ->
@@ -8129,6 +8152,7 @@ v_msg_rpbgetbucketreq(#rpbgetbucketreq{bucket = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tscoverageresp/3}).
 v_msg_tscoverageresp(#tscoverageresp{entries = F1},
 		     Path, TrUserData) ->
     if is_list(F1) ->
@@ -8142,6 +8166,7 @@ v_msg_tscoverageresp(#tscoverageresp{entries = F1},
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsqueryresp/3}).
 v_msg_tsqueryresp(#tsqueryresp{columns = F1, rows = F2,
 			       done = F3},
 		  Path, TrUserData) ->
@@ -8167,12 +8192,14 @@ v_msg_tsqueryresp(#tsqueryresp{columns = F1, rows = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbauthreq/3}).
 v_msg_rpbauthreq(#rpbauthreq{user = F1, password = F2},
 		 Path, _) ->
     v_type_bytes(F1, [user | Path]),
     v_type_bytes(F2, [password | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsqueryreq/3}).
 v_msg_tsqueryreq(#tsqueryreq{query = F1, stream = F2,
 			     cover_context = F3},
 		 Path, TrUserData) ->
@@ -8188,11 +8215,13 @@ v_msg_tsqueryreq(#tsqueryreq{query = F1, stream = F2,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbgetbucketresp/3}).
 v_msg_rpbgetbucketresp(#rpbgetbucketresp{props = F1},
 		       Path, TrUserData) ->
     v_msg_rpbbucketprops(F1, [props | Path], TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpberrorresp/3}).
 v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
 				 errcode = F2},
 		   Path, _) ->
@@ -8200,6 +8229,7 @@ v_msg_rpberrorresp(#rpberrorresp{errmsg = F1,
     v_type_uint32(F2, [errcode | Path]),
     ok.
 
+-dialyzer({nowarn_function,v_msg_tslistkeysresp/3}).
 v_msg_tslistkeysresp(#tslistkeysresp{keys = F1,
 				     done = F2},
 		     Path, TrUserData) ->
@@ -8215,8 +8245,10 @@ v_msg_tslistkeysresp(#tslistkeysresp{keys = F1,
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_tsputresp/3}).
 v_msg_tsputresp(#tsputresp{}, _Path, _) -> ok.
 
+-dialyzer({nowarn_function,v_enum_TsColumnType/2}).
 v_enum_TsColumnType('VARCHAR', _Path) -> ok;
 v_enum_TsColumnType('SINT64', _Path) -> ok;
 v_enum_TsColumnType('DOUBLE', _Path) -> ok;
@@ -8228,6 +8260,7 @@ v_enum_TsColumnType(V, Path) when is_integer(V) ->
 v_enum_TsColumnType(X, Path) ->
     mk_type_error({invalid_enum, 'TsColumnType'}, X, Path).
 
+-dialyzer({nowarn_function,'v_enum_RpbBucketProps.RpbReplMode'/2}).
 'v_enum_RpbBucketProps.RpbReplMode'('FALSE', _Path) ->
     ok;
 'v_enum_RpbBucketProps.RpbReplMode'('REALTIME',
@@ -8246,6 +8279,7 @@ v_enum_TsColumnType(X, Path) ->
 		   'RpbBucketProps.RpbReplMode'},
 		  X, Path).
 
+-dialyzer({nowarn_function,v_type_sint32/2}).
 v_type_sint32(N, _Path)
     when -2147483648 =< N, N =< 2147483647 ->
     ok;
@@ -8256,6 +8290,7 @@ v_type_sint32(X, Path) ->
     mk_type_error({bad_integer, sint32, signed, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_sint64/2}).
 v_type_sint64(N, _Path)
     when -9223372036854775808 =< N,
 	 N =< 9223372036854775807 ->
@@ -8267,6 +8302,7 @@ v_type_sint64(X, Path) ->
     mk_type_error({bad_integer, sint64, signed, 64}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -8277,6 +8313,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bool/2}).
 v_type_bool(false, _Path) -> ok;
 v_type_bool(true, _Path) -> ok;
 v_type_bool(0, _Path) -> ok;
@@ -8284,6 +8321,7 @@ v_type_bool(1, _Path) -> ok;
 v_type_bool(X, Path) ->
     mk_type_error(bad_boolean_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_double/2}).
 v_type_double(N, _Path) when is_float(N) -> ok;
 v_type_double(N, _Path) when is_integer(N) -> ok;
 v_type_double(infinity, _Path) -> ok;
@@ -8292,6 +8330,7 @@ v_type_double(nan, _Path) -> ok;
 v_type_double(X, Path) ->
     mk_type_error(bad_double_value, X, Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->

--- a/src/riak_yokozuna.proto
+++ b/src/riak_yokozuna.proto
@@ -12,6 +12,8 @@
  * git add -A; git commit -m 'Update erlang code from .proto files'
  */
 
+syntax = "proto2";
+
 // java package specifiers
 option java_package = "com.basho.riak.protobuf";
 option java_outer_classname = "RiakYokozunaPB";

--- a/src/riak_yokozuna_pb.erl
+++ b/src/riak_yokozuna_pb.erl
@@ -1653,11 +1653,13 @@ verify_msg(Msg, Opts) ->
     end.
 
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaschemagetreq/3}).
 v_msg_rpbyokozunaschemagetreq(#rpbyokozunaschemagetreq{name
 							   = F1},
 			      Path, _) ->
     v_type_bytes(F1, [name | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaschema/3}).
 v_msg_rpbyokozunaschema(#rpbyokozunaschema{name = F1,
 					   content = F2},
 			Path, _) ->
@@ -1670,6 +1672,7 @@ v_msg_rpbyokozunaschema(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbyokozunaschema}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaschemaputreq/3}).
 v_msg_rpbyokozunaschemaputreq(#rpbyokozunaschemaputreq{schema
 							   = F1},
 			      Path, TrUserData) ->
@@ -1677,6 +1680,7 @@ v_msg_rpbyokozunaschemaputreq(#rpbyokozunaschemaputreq{schema
 			    TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaschemagetresp/3}).
 v_msg_rpbyokozunaschemagetresp(#rpbyokozunaschemagetresp{schema
 							     = F1},
 			       Path, TrUserData) ->
@@ -1684,6 +1688,7 @@ v_msg_rpbyokozunaschemagetresp(#rpbyokozunaschemagetresp{schema
 			    TrUserData),
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaindex/3}).
 v_msg_rpbyokozunaindex(#rpbyokozunaindex{name = F1,
 					 schema = F2, n_val = F3},
 		       Path, _) ->
@@ -1699,6 +1704,7 @@ v_msg_rpbyokozunaindex(X, Path, _TrUserData) ->
     mk_type_error({expected_msg, rpbyokozunaindex}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaindexputreq/3}).
 v_msg_rpbyokozunaindexputreq(#rpbyokozunaindexputreq{index
 							 = F1,
 						     timeout = F2},
@@ -1709,6 +1715,7 @@ v_msg_rpbyokozunaindexputreq(#rpbyokozunaindexputreq{index
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaindexgetreq/3}).
 v_msg_rpbyokozunaindexgetreq(#rpbyokozunaindexgetreq{name
 							 = F1},
 			     Path, _) ->
@@ -1717,11 +1724,13 @@ v_msg_rpbyokozunaindexgetreq(#rpbyokozunaindexgetreq{name
     end,
     ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaindexdeletereq/3}).
 v_msg_rpbyokozunaindexdeletereq(#rpbyokozunaindexdeletereq{name
 							       = F1},
 				Path, _) ->
     v_type_bytes(F1, [name | Path]), ok.
 
+-dialyzer({nowarn_function,v_msg_rpbyokozunaindexgetresp/3}).
 v_msg_rpbyokozunaindexgetresp(#rpbyokozunaindexgetresp{index
 							   = F1},
 			      Path, TrUserData) ->
@@ -1737,6 +1746,7 @@ v_msg_rpbyokozunaindexgetresp(#rpbyokozunaindexgetresp{index
     end,
     ok.
 
+-dialyzer({nowarn_function,v_type_uint32/2}).
 v_type_uint32(N, _Path) when 0 =< N, N =< 4294967295 ->
     ok;
 v_type_uint32(N, Path) when is_integer(N) ->
@@ -1747,6 +1757,7 @@ v_type_uint32(X, Path) ->
     mk_type_error({bad_integer, uint32, unsigned, 32}, X,
 		  Path).
 
+-dialyzer({nowarn_function,v_type_bytes/2}).
 v_type_bytes(B, _Path) when is_binary(B) -> ok;
 v_type_bytes(B, _Path) when is_list(B) -> ok;
 v_type_bytes(X, Path) ->


### PR DESCRIPTION
`protoc` clients using libprotoc 3.0.0+ want `.proto` files to specify their protocol buffers syntax version.

This adds the syntax version to avoid warnings from libprotoc 3.0.0+.