### PR TITLE
Fill in release notes file up to 2.2.0.2

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -1,7 +1,15 @@
 Release Notes
 =============
 
+* [`2.2.0.2`](https://github.com/basho/riak_pb/compare/2.2.0.1...2.2.0.2)
+  * Add gset support.
+  * Add blob support.
+  * Add thumbs.
+* [`2.2.0.1`](https://github.com/basho/riak_pb/compare/2.2.0.0...2.2.0.1)
+  * Add field `allow_qbuf_reuse` for Riak TS.
+* [`2.2.0.0`](https://github.com/basho/riak_pb/compare/2.1.4.2...2.2.0.0)
 * `2.1.4.2`
  * Update `erlang_protobuffs` to `0.9.0`. Supports quoting reserved words in a `R15`-compatible way.
 * [`2.1.4.1`](https://github.com/basho/riak_pb/issues?q=milestone%3Ariak_pb-2.1.4.1)
  * OTP 19 support in `riak_pb` and dependencies.
+ 


### PR DESCRIPTION
I feel this is the minimal content, alternative is deleting the file altogether.

I went though this as I am looking at Riak KV 2.2.0 API, that includes riak_pb 2.2.0.0, and I wanted to understand whether riak_pb 2.2.0.{1,2} were relevant for Riak KV 2.2.0 (only gset may be).

(I did not inspect riak_pb 2.3.0.0.)