### PR TITLE
OTP20 compatability - suppress export_all warnings in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+- 20.1
 - 19.1
 - 18.3
 - 17.5

--- a/src/riak_pb_codec.erl
+++ b/src/riak_pb_codec.erl
@@ -31,6 +31,8 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
+-compile(nowarn_export_all).
+
 -endif.
 
 -export([encode/1,      %% riakc_pb:encode

--- a/test/bucket_props_codec_eqc.erl
+++ b/test/bucket_props_codec_eqc.erl
@@ -23,6 +23,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -define(QC_OUT(P), eqc:on_output(fun(F,TL) ->
                                          io:format(user, F, TL)

--- a/test/encoding_test.erl
+++ b/test/encoding_test.erl
@@ -1,5 +1,6 @@
 -module(encoding_test).
 -compile([export_all]).
+-compile(nowarn_export_all).
 -include_lib("eunit/include/eunit.hrl").
 -include("riak_pb_kv_codec.hrl").
 -include("riak_dt_pb.hrl").


### PR DESCRIPTION
Add ```-compile(nowarn_export_all)``` to suppress compiler errors when using ```-compile(export_all)``` in test modules.