### PR TITLE
Handle missing optional defaults

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,6 +27,7 @@
 
 {gpb_opts, [{module_name_suffix, "_pb"},
             {msg_name_to_lower, true},
+            {defaults_for_omitted_optionals, true},
             {i, "src"}]}.
 
 {provider_hooks, [


### PR DESCRIPTION
Older riak clients do not seem to encode optional defaults and possibly rely on the server for decoding and inserting the missing defaults.

Here's a dtfetchreq message from clients:

3.0 client
<<10,5,109,121,109,97,112,18,1,49,26,4,109,97,112,115,88,1>>
2.1.0.7 client
<<10,5,109,121,109,97,112,18,1,49,26,4,109,97,112,115>>

The <<88,1>> portion at the end of the binary is the return_context optional, which defaults to 1, as defined in the proto spec. When the 2.* client message is decoded by the server, the missing optional is set to undefined, which causes issues when fetching types:

`2020-08-11 07:39:01.028 [error] <0.9599.0> gen_fsm <0.9599.0> in state connected terminated with reason: {error,function_clause,[{riak_kv_pb_crdt,get_context,[<<131,108,0,0,0,2,104,2,109,0,0,0,8,197,82,177,11,162,225,36,190,97,2,104,2,109,0,0,0,12,197,82,177,11,162,225,37,8,0,0,0,1,97,2,106>>,undefined],[
{file,"/home/martincox/code/riak31/_build/default/lib/riak_kv/src/riak_kv_pb_crdt.erl"},{line,271}]},{riak_kv_pb_crdt,process_fetch_response,2,[{file,"/home/martincox/code/riak31/_build/default/lib/riak_kv/src/riak_kv_pb_crdt.erl"} `

Adding the defaults_for_omitted_optionals to gpb_opts mitigates the issue.