### PR TITLE
Extend the FetchClockNVal message

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -380,6 +380,9 @@ message RpbAaeFoldMergeBranchNValReq{
 message RpbAaeFoldFetchClocksNValReq{
     required uint32 n_val = 1;
     repeated uint32 id_filter = 2;
+    optional bool modified_range = 40;
+    optional uint32 last_mod_start = 41;
+    optional uint32 last_mod_end = 42;
 }
 
 message RpbAaeFoldMergeTreesRangeReq{


### PR DESCRIPTION
Need to make the bool optional so that requests from older clients  not providing this are accepted.  Will default to previous behaviour (i.e. false) if not provided