### PR TITLE
Add Cluster membership request/response message

### DIFF
--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -384,6 +384,21 @@ message RpbPushResp{
     optional uint32 realt_length = 12;
 }
 
+// Request a member of a cluster return the API addresses of other members
+message RpbMembershipReq{
+    optional bytes queuename = 1;
+}
+
+// An IP Port representing the API address of a cluster member 
+message RpbClusterMemberEntry {
+    required bytes ip = 1;
+    required uint32 port = 2;
+}
+
+message RpbMembershipResp{
+    repeated RpbClusterMemberEntry up_nodes = 1;
+}
+
 // AAE Fold requests
 message RpbAaeFoldMergeRootNValReq{
     required uint32 n_val = 1;

--- a/src/riak_pb_messages.csv
+++ b/src/riak_pb_messages.csv
@@ -77,6 +77,8 @@
 203,RpbFetchResp,riak_kv
 204,RpbPushReq,riak_kv
 205,RpbPushResp,riak_kv
+206,RpbMembershipReq,riak_kv
+207,RpbMembershipResp,riak_kv
 210,RpbAaeFoldMergeRootNValReq,riak_kv
 211,RpbAaeFoldMergeBranchNValReq,riak_kv
 212,RpbAaeFoldFetchClocksNValReq,riak_kv


### PR DESCRIPTION
Request to know about other members known by this member.  Option to add a queue name, although initially this may be ignored.

Implementation may not be responsive, should be used sparingly, rather than as a regular pre-cursor to requests.

https://github.com/basho/riak_kv/pull/1812