### PR TITLE
Remove eunit hrl usage

### DIFF
--- a/src/riak_pb_dt_codec.erl
+++ b/src/riak_pb_dt_codec.erl
@@ -23,8 +23,6 @@
 
 -include("riak_dt_pb.hrl").
 
--include_lib("eunit/include/eunit.hrl").
-
 -export([
          encode_fetch_request/2,
          encode_fetch_request/3,


### PR DESCRIPTION
I know this repo is not maintained but adding this for visibility. If you face this issue:

```
8.648 ==> riak_pb
8.648 Compiling 13 files (.erl)
8.674 src/riak_pb_dt_codec.erl:26:14: can't find include lib "eunit/include/eunit.hrl"
8.674 %   26| -include_lib("eunit/include/eunit.hrl").
8.674 %     |              ^
8.674 
13.25 could not compile dependency :riak_pb, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile riak_pb --force", update it with "mix deps.update riak_pb" or clean it with "mix deps.clean riak_pb"
```

then try to use the code from this branch.